### PR TITLE
Improve I18N

### DIFF
--- a/includes/class-health-wpvulnerability.php
+++ b/includes/class-health-wpvulnerability.php
@@ -80,7 +80,7 @@ class Health_WPVulnerability {
 			$result['actions']    .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'update-core.php' ) ),
-				__( 'Update WordPress' )
+				__( 'Update WordPress', 'wpvulnerability' )
 			);
 		}
 
@@ -122,7 +122,7 @@ class Health_WPVulnerability {
 			$result['actions']    .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'themes.php' ) ),
-				__( 'Update themes' )
+				__( 'Update themes', 'wpvulnerability' )
 			);
 		}
 
@@ -164,7 +164,7 @@ class Health_WPVulnerability {
 			$result['actions']    .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'plugins.php' ) ),
-				__( 'Update plugins' )
+				__( 'Update plugins', 'wpvulnerability' )
 			);
 		}
 


### PR DESCRIPTION
Suppose strings in your plugin are also used in WordPress core (e.g., **"Settings"**), you should still add your text domain. Otherwise, they’ll become untranslated if the core string changes (which happens). Please refer to [this article](https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#add-text-domain-to-strings).