### PR TITLE
Keep UI strings as a full sentence, not split as multiple variables

### DIFF
--- a/includes/class-wpvul-notification.php
+++ b/includes/class-wpvul-notification.php
@@ -192,9 +192,8 @@ class WPVUL_Notification {
 										<tr style="box-sizing: border-box; margin: 0;">
 											<td class="aligncenter content-block" style="box-sizing: border-box; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">';
 		$message .= sprintf(
-			// translators: %s the website of Databaase.
-			'%s <a href="%s">%s</a>',
-			__( 'Learn more about the WordPress Vulnerability Database API at', 'wpvulnerability' ),
+			// translators: %1$s the website of Databaase, %2$s database site name.
+			__( 'Learn more about the WordPress Vulnerability Database API at <a href="%1$s">%2$s</a>', 'wpvulnerability' ),
 			'https://vulnerability.wpsysadmin.com/',
 			'WPVulnerability'
 		);


### PR DESCRIPTION
Keep UI strings as a full sentence, not split as multiple variables. This action will make this modified sentence get a better translation.