### PR TITLE
2.0.3 preparation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: javiercasares, davidperez, lbonomo
 Tags: security, vulnerability, site-health
 Requires at least: 4.1
 Tested up to: 6.3
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 Requires PHP: 5.6
-Version: 2.0.2
+Version: 2.0.3
 License: EUPL v1.2
 License URI: https://www.eupl.eu/1.2/en/
 
@@ -70,6 +70,12 @@ Vulnerabilities in WordPress core, plugins and themes are documented.
 First of all, peace of mind. Investigate what the vulnerability is and, above all, check that you have the latest version of the compromised element. We actively recommend that you keep all your WordPress and its plugins up to date.
 
 == Changelog ==
+
+= 2.0.3 =
+* Validate secure requests to the API.
+* Reduce API timeout request time from 10.0 seconds to 2.5 seconds.
+* Compatibility: WordPress 4.1 - WordPress 6.3.
+* Compatibility: PHP 5.6 - PHP 8.3.
 
 = 2.0.2 =
 * Fix the Notification system.

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -168,11 +168,6 @@ function wpvulnerability_severity( $severity ) {
  */
 function wpvulnerability_get( $type, $slug = '' ) {
 
-	$args = array(
-		'timeout'   => 10000,
-		'sslverify' => false,
-	);
-
 	// Validate vulnerability type.
 	switch( trim( strtolower( $type ) ) ) {
 		case 'core':
@@ -212,7 +207,7 @@ function wpvulnerability_get( $type, $slug = '' ) {
 	if ( empty( $vulnerability ) ) {
 
 		$url = WPVULNERABILITY_API_HOST . $type . '/' . $slug . '/';
-		$response = wp_remote_get( $url, $args );
+		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( !is_wp_error( $response ) ) {
 
@@ -489,7 +484,7 @@ function wpvulnerability_get_statistics() {
 
 		$url = WPVULNERABILITY_API_HOST;
 		// Parse the JSON response into an associative array
-		$response = wp_remote_get( $url );
+		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( !is_wp_error( $response ) ) {
 

--- a/wpvulnerability.php
+++ b/wpvulnerability.php
@@ -5,7 +5,7 @@
  * Description: Check WordPress core, plugins, and theme vulnerabilities with information from the WordPress Vulnerability Database API.
  * Requires at least: 4.1
  * Requires PHP: 5.6
- * Version: 2.0.2
+ * Version: 2.0.3
  * Author: Javier Casares
  * Author URI: https://www.javiercasares.com/
  * Text Domain: wpvulnerability


### PR DESCRIPTION
- Validate secure requests to the API.
- Reduce API timeout request time from 10.0 seconds to 2.5 seconds.
- Compatibility: WordPress 4.1 - WordPress 6.3.
- Compatibility: PHP 5.6 - PHP 8.3.