### PR TITLE
v3.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,24 @@
 == Changelog ==
 
+= [3.1.1] - 2024-02-11 =
+
+**Fixed**
+
+* Fixes some possible PHP warnings when retrieving data from the API.
+* Delete old schedules when unistalling the plugin.
+* Fix how is printed the High severity.
+
+**Deleted**
+
+* The plugin will not show the Exploitability information.
+
+**Compatibility**
+
+* Compatibility: WordPress 4.1 - WordPress 6.5.
+* Compatibility: PHP 5.6 - PHP 8.3.
+* Compatibility: WordPress Coding Standards 3.0.1.
+* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.10.0.
+
 = [3.1.0] - 2024-02-04 =
 
 **Added**

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: javiercasares, davidperez, lbonomo, alexclassroom
 Tags: security, vulnerability, site-health
 Requires at least: 4.1
 Tested up to: 6.5
-Stable tag: 3.1.0
+Stable tag: 3.1.1
 Requires PHP: 5.6
-Version: 3.1.0
+Version: 3.1.1
 License: EUPL v1.2
 License URI: https://www.eupl.eu/1.2/en/
 
@@ -93,9 +93,28 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 * WordPress 4.1 - WordPress 6.5.
 * PHP 5.6 - PHP 8.3.
 * WordPress Coding Standards 3.0.1.
-* WP-CLI 2.3.0 - WP-CLI 2.9.0.
+* WP-CLI 2.3.0 - WP-CLI 2.10.0.
 
 == Changelog ==
+
+= [3.1.1] - 2024-02-11 =
+
+**Fixed**
+
+* Fixes some possible PHP warnings when retrieving data from the API.
+* Delete old schedules when unistalling the plugin.
+* Fix how is printed the High severity.
+
+**Deleted**
+
+* The plugin will not show the Exploitability information.
+
+**Compatibility**
+
+* Compatibility: WordPress 4.1 - WordPress 6.5.
+* Compatibility: PHP 5.6 - PHP 8.3.
+* Compatibility: WordPress Coding Standards 3.0.1.
+* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.10.0.
 
 = [3.1.0] - 2024-02-04 =
 
@@ -129,21 +148,6 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 * Compatibility: WordPress Coding Standards 3.0.1.
 * Compatibility: WP-CLI 2.3.0 - WP-CLI 2.9.0.
 
-= [3.0.1] - 2023-12-19 =
-
-**Fixed**
-
-* Test email with the actual vulnerabilities (or a test message), now forced when the button is clicked.
-* Fixed some strings (thanks @alexclassroom).
-* WordPress Coding Standards 3.0.1 up-to-date.
-
-**Compatibility**
-
-* Compatibility: WordPress 4.1 - WordPress 6.4.
-* Compatibility: PHP 5.6 - PHP 8.3.
-* Compatibility: WordPress Coding Standards 3.0.1.
-* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.9.0.
-
 == Security ==
 
 This plugin adheres to the following security measures and review protocols for each version:
@@ -159,7 +163,7 @@ This plugin adheres to the following security measures and review protocols for 
 
 == Vulnerabilities ==
 
-* No vulnerabilities have been published up to version 3.1.0.
+* No vulnerabilities have been published up to version 3.1.1.
 
 Found a security vulnerability? Please report it to us privately at the [WPVulnerability GitHub repository](https://github.com/javiercasares/wpvulnerability/security/advisories/new).
 

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -120,7 +120,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 							)
 						);
 					}
-
 				}
 
 				if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -41,10 +41,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 					$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 				}
-				$exploitable = null;
-				if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-					$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-				}
 
 				// Add the vulnerability details to the array.
 				array_push(
@@ -95,12 +91,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 					$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 				}
-				$exploitable = null;
-				if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-					$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-				}
 
-				if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+				if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 
 					array_push(
 						$vulnerabilities,
@@ -128,16 +120,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 							)
 						);
 					}
-					if ( ! is_null( $exploitable ) ) {
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10',
-							)
-						);
 
-					}
 				}
 
 				if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {
@@ -219,10 +202,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
-					$exploitable = null;
-					if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-						$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-					}
 
 					// Add the vulnerability details to the array.
 					array_push(
@@ -297,12 +276,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
-					$exploitable = null;
-					if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-						$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-					}
 
-					if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+					if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 
 						array_push(
 							$vulnerabilities,
@@ -329,16 +304,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 									'Vulnerability information' => __( 'Severity: ', 'wpvulnerability' ) . $severity,
 								)
 							);
-						}
-						if ( ! is_null( $exploitable ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10',
-								)
-							);
-
 						}
 					}
 
@@ -423,10 +388,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
-					$exploitable = null;
-					if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-						$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-					}
 
 					// Add the vulnerability details to the array.
 					array_push(
@@ -501,12 +462,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
-					$exploitable = null;
-					if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-						$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-					}
 
-					if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+					if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 
 						array_push(
 							$vulnerabilities,
@@ -533,16 +490,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 									'Vulnerability information' => __( 'Severity: ', 'wpvulnerability' ) . $severity,
 								)
 							);
-						}
-						if ( ! is_null( $exploitable ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10',
-								)
-							);
-
 						}
 					}
 

--- a/wpvulnerability-core.php
+++ b/wpvulnerability-core.php
@@ -64,10 +64,6 @@ function wpvulnerability_core_info_after() {
 		if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 			$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 		}
-		$exploitable = null;
-		if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-			$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-		}
 
 		$information .= '<tr>';
 		$information .= '<td style="max-width: 256px; min-width: 96px;">WordPress <b>' . wp_kses( $vulnerability['name'], 'strip' ) . '</b></td>';
@@ -79,16 +75,13 @@ function wpvulnerability_core_info_after() {
 			}
 			$information .= '</div>';
 		}
-		if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+		if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 			$information .= '<div style="padding-bottom: 5px;">';
 			if ( ! is_null( $score ) ) {
 				$information .= '<div>' . __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10</div>';
 			}
 			if ( ! is_null( $severity ) ) {
 				$information .= '<div>' . __( 'Severity: ', 'wpvulnerability' ) . $severity . '</div>';
-			}
-			if ( ! is_null( $exploitable ) ) {
-				$information .= '<div>' . __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10</div>';
 			}
 			$information .= '</div>';
 		}

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -330,15 +330,14 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0 ) {
 
 	if ( 1 === $data ) {
 
-		if( isset( $response['data'] ) ) {
+		if ( isset( $response['data'] ) ) {
 			$vulnerability = array(
 				'name'   => wp_kses( (string) $response['data']['name'], 'strip' ),
 				'link'   => esc_url( (string) $response['data']['link'] ),
 				'latest' => number_format( (int) $response['data']['latest'], 0, '.', '' ),
-				'closed' => number_format( (int) $response['data']['closed'], 0, '.', '' )
+				'closed' => number_format( (int) $response['data']['closed'], 0, '.', '' ),
 			);
 		}
-
 	} else {
 
 		// If there are no vulnerabilities, return false.

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -330,12 +330,14 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0 ) {
 
 	if ( 1 === $data ) {
 
-		$vulnerability = array(
-			'name'   => wp_kses( $response['data']['name'], 'strip' ),
-			'link'   => esc_url( $response['data']['link'] ),
-			'latest' => number_format( (int) $response['data']['latest'], 0, '.', '' ),
-			'closed' => number_format( (int) $response['data']['closed'], 0, '.', '' ),
-		);
+		if( isset( $response['data'] ) ) {
+			$vulnerability = array(
+				'name'   => wp_kses( (string) $response['data']['name'], 'strip' ),
+				'link'   => esc_url( (string) $response['data']['link'] ),
+				'latest' => number_format( (int) $response['data']['latest'], 0, '.', '' ),
+				'closed' => number_format( (int) $response['data']['closed'], 0, '.', '' )
+			);
+		}
 
 	} else {
 

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -167,7 +167,7 @@ function wpvulnerability_severity( $severity ) {
 		case 'm':
 			/* translators: Severity: Medium */
 			return __( 'Medium', 'wpvulnerability' );
-		case 'm':
+		case 'h':
 			/* translators: Severity: High */
 			return __( 'High', 'wpvulnerability' );
 		case 'c':

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -78,10 +78,6 @@ function wpvulnerability_plugin_info_after( $plugin_file, $plugin_data ) {
 		if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 			$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 		}
-		$exploitable = null;
-		if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-			$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-		}
 
 		$information .= '<tr>';
 		$information .= '<td style="max-width: 256px; min-width: 96px;"><b>' . wp_kses( $vulnerability['versions'], 'strip' ) . '</b></td>';
@@ -103,16 +99,13 @@ function wpvulnerability_plugin_info_after( $plugin_file, $plugin_data ) {
 			}
 			$information .= '</div>';
 		}
-		if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+		if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 			$information .= '<div style="padding-bottom: 5px;">';
 			if ( ! is_null( $score ) ) {
 				$information .= '<div>' . __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10</div>';
 			}
 			if ( ! is_null( $severity ) ) {
 				$information .= '<div>' . __( 'Severity: ', 'wpvulnerability' ) . $severity . '</div>';
-			}
-			if ( ! is_null( $exploitable ) ) {
-				$information .= '<div>' . __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10</div>';
 			}
 			$information .= '</div>';
 		}

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -474,7 +474,7 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 				if ( $warning_date ) {
 
 					echo '<p><strong>⚠️ ';
-					_e( 'It hasn\'t been updated in over a year.', 'wpvulnerability' );
+					esc_html_e( 'It hasn\'t been updated in over a year.', 'wpvulnerability' );
 					echo '</strong></p>';
 
 				}
@@ -482,7 +482,7 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 				if ( $warning_closed ) {
 
 					echo '<p><strong>⚠️ ';
-					_e( 'It may no longer be available (closed?).', 'wpvulnerability' );
+					esc_html_e( 'It may no longer be available (closed?).', 'wpvulnerability' );
 					echo '</strong></p>';
 
 				}

--- a/wpvulnerability-process.php
+++ b/wpvulnerability-process.php
@@ -51,10 +51,6 @@ function wpvulnerability_html( $type, $vulnerabilities ) {
 			if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 				$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 			}
-			$exploitable = null;
-			if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-				$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-			}
 
 			$html .= '<h4>' . wp_kses( $vulnerability['name'], 'strip' ) . '</h4>';
 			if ( (int) $vulnerability['closed'] || (int) $vulnerability['unfixed'] ) {
@@ -74,16 +70,13 @@ function wpvulnerability_html( $type, $vulnerabilities ) {
 				}
 				$html .= '</div>';
 			}
-			if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+			if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 				$html .= '<div style="padding-bottom: 5px;">';
 				if ( ! is_null( $score ) ) {
 					$html .= '<div>' . __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10</div>';
 				}
 				if ( ! is_null( $severity ) ) {
 					$html .= '<div>' . __( 'Severity: ', 'wpvulnerability' ) . $severity . '</div>';
-				}
-				if ( ! is_null( $exploitable ) ) {
-					$html .= '<div>' . __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10</div>';
 				}
 				$html .= '</div>';
 			}
@@ -113,10 +106,6 @@ function wpvulnerability_html( $type, $vulnerabilities ) {
 			if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 				$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 			}
-			$exploitable = null;
-			if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-				$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-			}
 
 			$html .= '<h3> WordPress ' . wp_kses( $vulnerability['name'], 'strip' ) . '</h3>';
 			if ( count( $what ) ) {
@@ -126,16 +115,13 @@ function wpvulnerability_html( $type, $vulnerabilities ) {
 				}
 				$html .= '</div>';
 			}
-			if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+			if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 				$html .= '<div style="padding-bottom: 5px;">';
 				if ( ! is_null( $score ) ) {
 					$html .= '<div>' . __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10</div>';
 				}
 				if ( ! is_null( $severity ) ) {
 					$html .= '<div>' . __( 'Severity: ', 'wpvulnerability' ) . $severity . '</div>';
-				}
-				if ( ! is_null( $exploitable ) ) {
-					$html .= '<div>' . __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10</div>';
 				}
 				$html .= '</div>';
 			}

--- a/wpvulnerability-run.php
+++ b/wpvulnerability-run.php
@@ -402,6 +402,9 @@ function wpvulnerability_deactivation() {
 
 	wp_unschedule_event( wp_next_scheduled( 'wpvulnerability_update_database' ), 'wpvulnerability_update_database' );
 	wp_clear_scheduled_hook( 'wpvulnerability_update_database' );
+
+	wp_unschedule_event( wp_next_scheduled( 'wpvulnerability_pull_db_data_event' ), 'wpvulnerability_pull_db_data_event' );
+	wp_clear_scheduled_hook( 'wpvulnerability_pull_db_data_event' );
 }
 
 /**

--- a/wpvulnerability-themes.php
+++ b/wpvulnerability-themes.php
@@ -79,10 +79,6 @@ function wpvulnerability_theme_info_after( $theme_file, $theme_data ) {
 		if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 			$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 		}
-		$exploitable = null;
-		if ( isset( $vulnerability['impact']['cvss']['exploitable'] ) ) {
-			$exploitable = number_format( (float) $vulnerability['impact']['cvss']['exploitable'], 1, '.', '' );
-		}
 
 		$information .= '<tr>';
 		$information .= '<td style="max-width: 256px; min-width: 96px;"><b>' . wp_kses( $vulnerability['versions'], 'strip' ) . '</b></td>';
@@ -104,16 +100,13 @@ function wpvulnerability_theme_info_after( $theme_file, $theme_data ) {
 			}
 			$information .= '</div>';
 		}
-		if ( ! is_null( $score ) || ! is_null( $severity ) || ! is_null( $exploitable ) ) {
+		if ( ! is_null( $score ) || ! is_null( $severity ) ) {
 			$information .= '<div style="padding-bottom: 5px;">';
 			if ( ! is_null( $score ) ) {
 				$information .= '<div>' . __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10</div>';
 			}
 			if ( ! is_null( $severity ) ) {
 				$information .= '<div>' . __( 'Severity: ', 'wpvulnerability' ) . $severity . '</div>';
-			}
-			if ( ! is_null( $exploitable ) ) {
-				$information .= '<div>' . __( 'Exploitability: ', 'wpvulnerability' ) . $exploitable . ' / 10</div>';
 			}
 			$information .= '</div>';
 		}

--- a/wpvulnerability.php
+++ b/wpvulnerability.php
@@ -5,7 +5,7 @@
  * Description: Check WordPress Core, Plugins, Themes, and PHP vulnerabilities with information from the WordPress Vulnerability Database API.
  * Requires at least: 4.1
  * Requires PHP: 5.6
- * Version: 3.1.0
+ * Version: 3.1.1
  * Author: Javier Casares
  * Author URI: https://www.javiercasares.com/
  * License: EUPL v1.2
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 /**
  * Set some constants that I can change in future verions
  */
-define( 'WPVULNERABILITY_PLUGIN_VERSION', '3.1.0' );
+define( 'WPVULNERABILITY_PLUGIN_VERSION', '3.1.1' );
 define( 'WPVULNERABILITY_API_HOST', 'https://www.wpvulnerability.net/' );
 define( 'WPVULNERABILITY_CACHE_HOURS', 12 );
 


### PR DESCRIPTION
*Fixed**

* Fixes some possible PHP warnings when retrieving data from the API.
* Delete old schedules when unistalling the plugin.
* Fix how is printed the High severity.

**Deleted**

* The plugin will not show the Exploitability information.

**Compatibility**

* Compatibility: WordPress 4.1 - WordPress 6.5.
* Compatibility: PHP 5.6 - PHP 8.3.
* Compatibility: WordPress Coding Standards 3.0.1.
* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.10.0.