### PR TITLE
Version 3.2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,24 @@
 == Changelog ==
 
+= [3.2.1] - 2024-05-07 =
+
+**Fixed**
+
+* In some cases (when calling it directly, or wget), the cron was not working and gave an error.
+* The license had a non-compliance ID. Now, same license but working.
+
+**Changed**
+
+* The URL from the API is using its own domain name.
+
+**Compatibility**
+
+* WordPress 4.1 - WordPress 6.6-alpha.
+* PHP 5.6 - PHP 8.3.
+* WordPress Coding Standards 3.1.0.
+* WP-CLI 2.3.0 - WP-CLI 2.10.0.
+* Plugin Check (PCP)
+
 = [3.2.0] - 2024-02-13 =
 
 **Added**

--- a/readme.txt
+++ b/readme.txt
@@ -2,18 +2,18 @@
 Contributors: javiercasares, davidperez, lbonomo, alexclassroom
 Tags: security, vulnerability, site-health
 Requires at least: 4.1
-Tested up to: 6.5
-Stable tag: 3.2.0
+Tested up to: 6.6-alpha
+Stable tag: 3.2.1
 Requires PHP: 5.6
-Version: 3.2.0
-License: EUPL v1.2
+Version: 3.2.1
+License: EUPL-1.2
 License URI: https://www.eupl.eu/1.2/en/
 
-Enhance your WordPress site's security with this plugin, leveraging the comprehensive [WordPress Vulnerability Database API](https://vulnerability.wpsysadmin.com/). Stay informed about vulnerabilities in WordPress Core, Plugins, Themes, and PHP. Take proactive steps to safeguard your site.
+Receive information about possible vulnerabilities in your WordPress from [WordPress Vulnerability Database API](https://www.wpvulnerability.com/).
 
 == Description ==
 
-This plugin taps into the power of the free and unlimited [WordPress Vulnerability Database API](https://vulnerability.wpsysadmin.com/) to deliver vulnerability assessments directly within your WordPress dashboard. It's an essential tool for website administrators, developers, and anyone keen on maintaining a secure WordPress environment.
+This plugin taps into the power of the free and unlimited [WordPress Vulnerability Database API](https://www.wpvulnerability.com/) to deliver vulnerability assessments directly within your WordPress dashboard. It's an essential tool for website administrators, developers, and anyone keen on maintaining a secure WordPress environment.
 
 Secure your WordPress experience today, your first line of defense against vulnerabilities!
 
@@ -94,12 +94,32 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 
 == Compatibility ==
 
-* WordPress 4.1 - WordPress 6.5.
+* WordPress 4.1 - WordPress 6.6-alpha.
 * PHP 5.6 - PHP 8.3.
-* WordPress Coding Standards 3.0.1.
+* WordPress Coding Standards 3.1.0.
 * WP-CLI 2.3.0 - WP-CLI 2.10.0.
+* Plugin Check (PCP)
 
 == Changelog ==
+
+= [3.2.1] - 2024-05-07 =
+
+**Fixed**
+
+* In some cases (when calling it directly, or wget), the cron was not working and gave an error.
+* The license had a non-compliance ID. Now, same license but working.
+
+**Changed**
+
+* The URL from the API is using its own domain name.
+
+**Compatibility**
+
+* WordPress 4.1 - WordPress 6.6-alpha.
+* PHP 5.6 - PHP 8.3.
+* WordPress Coding Standards 3.1.0.
+* WP-CLI 2.3.0 - WP-CLI 2.10.0.
+* Plugin Check (PCP)
 
 = [3.2.0] - 2024-02-13 =
 
@@ -134,25 +154,6 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 * Compatibility: WordPress Coding Standards 3.0.1.
 * Compatibility: WP-CLI 2.3.0 - WP-CLI 2.10.0.
 
-= [3.1.0] - 2024-02-04 =
-
-**Added**
-
-* A new column in the plugin list, with the last updated day (and diff).
-* A notice if the plugin is closed in the WordPress.org repo.
-
-**Fixed**
-
-* Fixes the schedule in some cases.
-* Fixes the PHP format (using always the n.n / n.n.n format).
-
-**Compatibility**
-
-* Compatibility: WordPress 4.1 - WordPress 6.5.
-* Compatibility: PHP 5.6 - PHP 8.3.
-* Compatibility: WordPress Coding Standards 3.0.1.
-* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.9.0.
-
 = Previous versions =
 
 If you want to see the full changelog, visit the [changelog.txt](https://plugins.trac.wordpress.org/browser/wpvulnerability/trunk/changelog.txt) file.
@@ -165,6 +166,7 @@ This plugin adheres to the following security measures and review protocols for 
 * [WordPress Plugin Security](https://developer.wordpress.org/plugins/wordpress-org/plugin-security/)
 * [WordPress APIs Security](https://developer.wordpress.org/apis/security/)
 * [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards)
+* [Plugin Check (PCP)](https://wordpress.org/plugins/plugin-check/)
 
 == Privacy ==
 
@@ -172,7 +174,7 @@ This plugin adheres to the following security measures and review protocols for 
 
 == Vulnerabilities ==
 
-* No vulnerabilities have been published up to version 3.2.0.
+* No vulnerabilities have been published up to version 3.2.1.
 
 Found a security vulnerability? Please report it to us privately at the [WPVulnerability GitHub repository](https://github.com/javiercasares/wpvulnerability/security/advisories/new).
 

--- a/wpvulnerability.php
+++ b/wpvulnerability.php
@@ -2,13 +2,13 @@
 /**
  * Plugin Name: WPVulnerability
  * Plugin URI: https://vulnerability.wpsysadmin.com/
- * Description: Check WordPress Core, Plugins, Themes, and PHP vulnerabilities with information from the WordPress Vulnerability Database API.
+ * Description: Receive information about possible vulnerabilities in your WordPress from WordPress Vulnerability Database API.
  * Requires at least: 4.1
  * Requires PHP: 5.6
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: Javier Casares
  * Author URI: https://www.javiercasares.com/
- * License: EUPL v1.2
+ * License: EUPL-1.2
  * License URI: https://www.eupl.eu/1.2/en/
  * Text Domain: wpvulnerability
  * Domain Path: /languages

--- a/wpvulnerability.php
+++ b/wpvulnerability.php
@@ -97,7 +97,7 @@ function wpvulnerability_plugin_init() {
 /*
  * Only load if it's admin / super admin
  */
-if ( ( ! is_multisite() && is_admin() ) || ( is_multisite() && ( is_network_admin() || is_main_site() ) ) || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+if ( ( ! is_multisite() && is_admin() ) || ( is_multisite() && ( is_network_admin() || is_main_site() ) ) || ( defined( 'WP_CLI' ) && WP_CLI ) || wp_doing_cron() ) {
 
 	require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-run.php';
 	register_activation_hook( WPVULNERABILITY_PLUGIN_FILE, 'wpvulnerability_activation' );


### PR DESCRIPTION
# [3.2.1] - 2024-05-07

## Fixed

* In some cases (when calling it directly, or wget), the cron was not working and gave an error.
* The license had a non-compliance ID. Now, same license but working.

## Changed

* The URL from the API is using its own domain name.

## Compatibility

* WordPress 4.1 - WordPress 6.6-alpha.
* PHP 5.6 - PHP 8.3.
* WordPress Coding Standards 3.1.0.
* WP-CLI 2.3.0 - WP-CLI 2.10.0.
* Plugin Check (PCP)