### PR TITLE
Set a Define for the From: email

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 == Changelog ==
 
+= [3.2.1 ???] - 2024-05-NN ??? =
+
+**Added**
+
+* Configure a different `From:` email to send the vulnerabilities. [+ information](https://www.wpvulnerability.com/plugin/)
+
+**Compatibility**
+
+* WordPress 4.1 - WordPress 6.6.
+* PHP 5.6 - PHP 8.3.
+* WordPress Coding Standards 3.1.0.
+* WP-CLI 2.3.0 - WP-CLI 2.10.0.
+* Plugin Check (PCP)
+
 = [3.2.0] - 2024-05-08 =
 
 **Added**

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,9 @@ Configure the plugin to send periodic notifications about your site's security s
 * Privacy-Conscious: The plugin operates with a strong commitment to privacy. It does not store any data from your site nor retrieves personal or sensitive information.
 * Respect for Data Integrity: We understand the importance of your site’s integrity. The plugin works discreetly in the background, ensuring that your content and data remain untouched and unaffected during security checks.
 
-= WP-CLI =
+= Using the plugin =
+
+== WP-CLI ==
 
 And then, You will find these wpcli commands:
 
@@ -53,6 +55,16 @@ And then, You will find these wpcli commands:
 * `wp wpvulnerability php`: List PHP vulnerabilities.
 * `wp wpvulnerability apache`: List Apache HTTPD vulnerabilities.
 * `wp wpvulnerability nginx`: List nginx vulnerabilities.
+
+== Configurations ==
+
+**From mail**
+
+_Since WPVulnerability 3.2.1_
+
+If, for some reason, you need the emails sent by the plugin to have a From different from the site administrator, you can change it from the wp-config.php by adding a constant:
+
+`define( 'WPVULNERABILITY_MAIL', 'sender@example.com' );`
 
 = Data reliability =
 
@@ -102,6 +114,20 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 
 == Changelog ==
 
+= [3.2.1 ???] - 2024-05-NN ??? =
+
+**Added**
+
+* Configure a different `From:` email to send the vulnerabilities. [+ information](https://www.wpvulnerability.com/plugin/)
+
+**Compatibility**
+
+* WordPress 4.1 - WordPress 6.6.
+* PHP 5.6 - PHP 8.3.
+* WordPress Coding Standards 3.1.0.
+* WP-CLI 2.3.0 - WP-CLI 2.10.0.
+* Plugin Check (PCP)
+
 = [3.2.0] - 2024-05-08 =
 
 **Added**
@@ -135,25 +161,6 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 * WordPress Coding Standards 3.1.0.
 * WP-CLI 2.3.0 - WP-CLI 2.10.0.
 * Plugin Check (PCP)
-
-= [3.1.1] - 2024-02-11 =
-
-**Fixed**
-
-* Fixes some possible PHP warnings when retrieving data from the API.
-* Delete old schedules when unistalling the plugin.
-* Fix how is printed the High severity.
-
-**Deleted**
-
-* The plugin will not show the Exploitability information.
-
-**Compatibility**
-
-* Compatibility: WordPress 4.1 - WordPress 6.5.
-* Compatibility: PHP 5.6 - PHP 8.3.
-* Compatibility: WordPress Coding Standards 3.0.1.
-* Compatibility: WP-CLI 2.3.0 - WP-CLI 2.10.0.
 
 = Previous versions =
 

--- a/wpvulnerability-notifications.php
+++ b/wpvulnerability-notifications.php
@@ -308,6 +308,17 @@ function wpvulnerability_execute_notification( $forced = false ) {
 	} elseif ( ! is_multisite() ) {
 		$admin_email = get_bloginfo( 'admin_email' );
 	}
+	$from_email = $admin_email;
+
+	if ( defined( 'WPVULNERABILITY_MAIL' ) ) {
+
+		$wpvulnerability_sender_email = sanitize_email( trim( WPVULNERABILITY_MAIL ) );
+		if ( is_email( $wpvulnerability_sender_email ) ) {
+			$from_email = $wpvulnerability_sender_email;
+		}
+		unset( $wpvulnerability_sender_email );
+
+	}
 
 	// Prepare email subject and content.
 	$email_subject = sprintf(
@@ -320,7 +331,7 @@ function wpvulnerability_execute_notification( $forced = false ) {
 
 	// Prepare email headers.
 	$email_headers   = array();
-	$email_headers[] = 'From: WPVulnerability <' . $admin_email . '>';
+	$email_headers[] = 'From: WPVulnerability <' . $from_email . '>';
 	$email_headers[] = 'Content-Type: text/html; charset=UTF-8';
 
 	// Send email.


### PR DESCRIPTION
From mail

If, for some reason, you need the emails sent by the plugin to have a From different from the site administrator, you can change it from the wp-config.php by adding a constant:

`define( 'WPVULNERABILITY_MAIL', 'sender@example.com' );`