### PR TITLE
New WP-CLI formats and Global caches / reload fixed

### DIFF
--- a/wpvulnerability-admin.php
+++ b/wpvulnerability-admin.php
@@ -583,8 +583,7 @@ function wpvulnerability_admin_dashboard_content() {
  */
 function wpvulnerability_admin_dashboard() {
 
-	$user = wp_get_current_user();
-	if ( current_user_can( 'install_plugins' ) && ! is_multisite() ) {
+	if ( wpvulnerability_capabilities() ) {
 		wp_add_dashboard_widget( 'wpvulnerability', __( 'WPVulnerability Status', 'wpvulnerability' ), 'wpvulnerability_admin_dashboard_content', null, null, 'side', 'high' );
 	}
 }

--- a/wpvulnerability-adminms.php
+++ b/wpvulnerability-adminms.php
@@ -625,8 +625,7 @@ function wpvulnerability_admin_dashboard_content() {
  */
 function wpvulnerability_admin_dashboard() {
 
-	$user = wp_get_current_user();
-	if ( current_user_can( 'install_plugins' ) && is_super_admin( $user->ID ) ) {
+	if ( wpvulnerability_capabilities() ) {
 		wp_add_dashboard_widget( 'wpvulnerability', __( 'WPVulnerability Status', 'wpvulnerability' ), 'wpvulnerability_admin_dashboard_content', null, null, 'side', 'high' );
 	}
 }

--- a/wpvulnerability-apache.php
+++ b/wpvulnerability-apache.php
@@ -12,9 +12,12 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 /**
  * Retrieves vulnerabilities for an Apache HTTPD version and updates its data.
  *
+ * This function detects the installed Apache HTTPD version, checks for vulnerabilities using an external API,
+ * and updates the Apache HTTPD data array with the vulnerabilities found.
+ *
  * @since 3.2.0
  *
- * @return array The updated Apache HTTPD data array.
+ * @return array The updated Apache HTTPD data array containing vulnerability information.
  */
 function wpvulnerability_get_fresh_apache_vulnerabilities() {
 
@@ -48,88 +51,88 @@ function wpvulnerability_get_fresh_apache_vulnerabilities() {
 
 /**
  * Get Installed Apache HTTPD
- * Retrieves the list of installed Apache HTTPD, checks for vulnerabilities, caches the data, and sends an email notification if vulnerabilities are detected.
+ *
+ * Retrieves the list of installed Apache HTTPD versions, checks for vulnerabilities,
+ * caches the data, and sends an email notification if vulnerabilities are detected.
  *
  * @since 3.2.0
  *
- * @return string JSON-encoded array of Apache HTTPD data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of Apache HTTPD data with vulnerabilities and vulnerable status.
  */
 function wpvulnerability_apache_get_installed() {
 
 	$wpvulnerability_apache_vulnerable = 0;
 
+	// Retrieve fresh vulnerabilities for the installed Apache HTTPD version.
 	$apache = wpvulnerability_get_fresh_apache_vulnerabilities();
 
+	// Check if the Apache HTTPD version is vulnerable and count the vulnerabilities.
 	if ( isset( $apache['vulnerable'] ) && (int) $apache['vulnerable'] ) {
-
 		$wpvulnerability_apache_vulnerable = count( $apache['vulnerabilities'] );
-
 	}
 
+	// Cache the vulnerability data and the timestamp for cache expiration.
 	if ( is_multisite() ) {
-
 		update_site_option( 'wpvulnerability-apache', wp_json_encode( $apache ) );
 		update_site_option( 'wpvulnerability-apache-vulnerable', wp_json_encode( number_format( $wpvulnerability_apache_vulnerable, 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
+		update_site_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+	} else {
 		update_option( 'wpvulnerability-apache', wp_json_encode( $apache ) );
 		update_option( 'wpvulnerability-apache-vulnerable', wp_json_encode( number_format( $wpvulnerability_apache_vulnerable, 0, '.', '' ) ) );
-
+		update_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 	}
 
+	// Return the JSON-encoded array of Apache HTTPD data.
 	return wp_json_encode( $apache );
 }
 
 /**
  * Get the cached Apache HTTPD vulnerabilities or update the cache if it's stale or missing.
  *
+ * This function checks the cache for stored Apache HTTPD vulnerabilities. If the cache is stale or missing,
+ * it updates the cache with the latest vulnerabilities data.
+ *
  * @since 3.2.0
  *
- * @return array Array of Apache HTTPD with their vulnerabilities.
+ * @return array Array of Apache HTTPD data with their vulnerabilities.
  */
 function wpvulnerability_apache_get_vulnerabilities() {
 
 	if ( is_multisite() ) {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached Apache HTTPD data and decode it.
 		$apache_data_cache = json_decode( get_site_option( 'wpvulnerability-apache-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed Apache HTTPD data and decode it.
 		$apache_data = json_decode( get_site_option( 'wpvulnerability-apache' ), true );
 
-	} elseif ( ! is_multisite() ) {
+	} else {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached Apache HTTPD data and decode it.
 		$apache_data_cache = json_decode( get_option( 'wpvulnerability-apache-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed Apache HTTPD data and decode it.
 		$apache_data = json_decode( get_option( 'wpvulnerability-apache' ), true );
 
 	}
 
-	// If the cache is stale or the plugin data is empty, update the cache.
+	// If the cache is stale or the Apache HTTPD data is empty, update the cache.
 	if ( $apache_data_cache < time() || empty( $apache_data ) ) {
 
-		// Get the installed plugin data and update the cache.
+		// Get the installed Apache HTTPD data and update the cache.
 		$apache_data = json_decode( wpvulnerability_apache_get_installed(), true );
 
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
 	return $apache_data;
 }
 
 /**
- * Update the Apache HTTPD cache and remove any old cache data
+ * Update the Apache HTTPD cache and remove any old cache data.
+ *
+ * This function refreshes the cache for Apache HTTPD vulnerabilities by calling the function
+ * that retrieves and updates the installed Apache HTTPD data, ensuring that the cache contains
+ * the most recent information.
  *
  * @since 3.2.0
  *
@@ -137,16 +140,6 @@ function wpvulnerability_apache_get_vulnerabilities() {
  */
 function wpvulnerability_apache_get_vulnerabilities_clean() {
 
-	// Update the installed plugins cache.
+	// Update the installed Apache HTTPD cache.
 	wpvulnerability_apache_get_installed();
-
-	if ( is_multisite() ) {
-
-		update_site_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
-		update_option( 'wpvulnerability-apache-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	}
 }

--- a/wpvulnerability-apache.php
+++ b/wpvulnerability-apache.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @return array The updated Apache HTTPD data array.
  */
-function get_fresh_apache_vulnerabilities() {
+function wpvulnerability_get_fresh_apache_vulnerabilities() {
 
 	$apache_version = null;
 	$webserver      = wpvulnerability_detect_webserver();
@@ -32,7 +32,7 @@ function get_fresh_apache_vulnerabilities() {
 	// Retrieve vulnerabilities for the Apache HTTPD using its version.
 	if ( $apache_version ) {
 
-		$apache_api_response = wpvulnerability_get_apache( $apache_version );
+		$apache_api_response = wpvulnerability_get_apache( $apache_version, 0 );
 
 		// If vulnerabilities are found, update the Apache HTTPD data accordingly.
 		if ( ! empty( $apache_api_response ) ) {
@@ -58,7 +58,7 @@ function wpvulnerability_apache_get_installed() {
 
 	$wpvulnerability_apache_vulnerable = 0;
 
-	$apache = get_fresh_apache_vulnerabilities();
+	$apache = wpvulnerability_get_fresh_apache_vulnerabilities();
 
 	if ( isset( $apache['vulnerable'] ) && (int) $apache['vulnerable'] ) {
 

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -185,6 +185,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 */
 	function wpvulnerability_cli_plugins( $args, $format ) {
 
+		// Validate the format.
 		switch ( $format ) {
 			case 'table':
 				$format = 'table';
@@ -206,189 +207,149 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		}
 
 		$plugins_complete = array();
+		$vulnerabilities = array();
 
 		// Loop through each plugin vulnerability.
 		foreach ( $plugin_vulnerabilities as $plugin ) {
 
 			if ( 1 === $plugin['vulnerable'] ) {
 
-				$plugins_complete[] = $plugin;
+				$plugins_complete_temp                 = array();
+				$plugins_complete_temp_vulnerabilities = array();
 
-				$name = trim( html_entity_decode( wp_kses( (string) $plugin['Name'], 'strip' ) ) );
-
-				if ( 'table' === $format ) {
-					// Output the plugin name with red color.
-					WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
-				}
+				// Process theme name and slug.
+				$plugins_complete_temp['name'] = trim( html_entity_decode( wp_kses( (string) $plugin['Name'], 'strip' ) ) );
+				$plugins_complete_temp['slug'] = trim( html_entity_decode( wp_kses( (string) $plugin['slug'], 'strip' ) ) );
 
 				// Prepare the vulnerabilities array for table format output.
-				$vulnerabilities = array();
 				foreach ( $plugin['vulnerabilities'] as $vulnerability ) {
 
-					$severity = null;
+					// Process vulnerability severity.
+					$plugins_complete_temp_vulnerabilities['severity'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+						$plugins_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					// Add the vulnerability details to the array.
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => trim( html_entity_decode( wp_kses( (string) $vulnerability['versions'], 'strip' ) ) ),
-							'Vulnerability information' => '[*] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) ),
-						)
-					);
-					if ( (int) $vulnerability['closed'] || (int) $vulnerability['unfixed'] ) {
-						if ( (int) $vulnerability['closed'] ) {
+					// Process vulnerability details.
+					$plugins_complete_temp_vulnerabilities['version'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['versions'], 'strip' ) ) );
+					$plugins_complete_temp_vulnerabilities['name']    = trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) );
+					$plugins_complete_temp_vulnerabilities['closed']  = (int) $vulnerability['closed'];
+					$plugins_complete_temp_vulnerabilities['unfixed'] = (int) $vulnerability['unfixed'];
 
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '*** ' . __( 'This plugin is closed. Please replace it with another.', 'wpvulnerability' ) . ' ***',
-								)
-							);
-
-						}
-						if ( (int) $vulnerability['unfixed'] ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '*** ' . __( 'This vulnerability appears to be unpatched. Stay tuned for upcoming plugin updates.', 'wpvulnerability' ) . ' ***',
-								)
-							);
-
-						}
-					}
-
-					$what = array();
+					// Process CWE details.
+					$plugins_complete_temp_vulnerabilities['cwe'] = array();
 					if ( isset( $vulnerability['impact']['cwe'] ) && count( $vulnerability['impact']['cwe'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $vulnerability['impact']['cwe'] as $vulnerability_cwe ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
-								)
+							$plugins_complete_temp_vulnerabilities['cwe'][] = array(
+								'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
+								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
 							);
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
-								)
-							);
-
 						}
 					}
 
-					$score = null;
+					// Process CVSS score.
+					$plugins_complete_temp_vulnerabilities['score'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['score'] ) ) {
-						$score = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
+						$plugins_complete_temp_vulnerabilities['score'] = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
 					}
-					$severity = null;
+					$plugins_complete_temp_vulnerabilities['severity'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+						$plugins_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					if ( ! is_null( $score ) || ! is_null( $severity ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
-						if ( ! is_null( $score ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10',
-								)
-							);
-						}
-						if ( ! is_null( $severity ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Severity: ', 'wpvulnerability' ) . $severity,
-								)
-							);
-						}
-					}
-
+					// Process vulnerability sources.
+					$plugins_complete_temp_vulnerabilities['source'] = array();
 					if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $vulnerability['source'] as $vulnerability_source ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
-								)
+							$plugins_complete_temp_vulnerabilities['source'][] = array(
+								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
+								'link' => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
 							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => ' ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-								)
-							);
-
 						}
 					}
 
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
+					$plugins_complete_temp['vulnerabilities'][] = $plugins_complete_temp_vulnerabilities;
+					unset( $plugins_complete_temp_vulnerabilities, $vulnerability );
 				}
 
-				if ( 'table' === $format ) {
-					// Format and output the vulnerabilities in a table.
-					WP_CLI\Utils\format_items(
-						'table',
+				$plugins_complete[] = $plugins_complete_temp;
+				unset( $plugins_complete_temp );
+			}
+			unset( $plugin );
+		}
+
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
+
+			foreach ( $plugins_complete as $p_vuln ) {
+				$v_name = $p_vuln['slug'];
+
+				foreach ( $p_vuln['vulnerabilities'] as $p_vul ) {
+
+					$v_version = $p_vul['version'];
+
+					// Determine if vulnerability is fixed.
+					switch ( $p_vul['unfixed'] ) {
+						default:
+						case 0:
+							$v_fixed = 'yes';
+							break;
+						case 1:
+							$v_fixed = 'no';
+							break;
+					}
+
+					// Determine if theme is closed.
+					switch ( $p_vul['closed'] ) {
+						default:
+						case 0:
+							$v_closed = 'no';
+							break;
+						case 1:
+							$v_closed = 'yes';
+							break;
+					}
+					$v_score    = $p_vul['score'];
+					$v_severity = $p_vul['severity'];
+
+					// Compile CWE descriptions.
+					$v_description_array = array();
+					foreach ( $p_vul['cwe'] as $p_cwe ) {
+						if ( isset( $p_cwe['name'] ) ) {
+							$v_description_array[] = $p_cwe['name'];
+						}
+					}
+					$v_description = trim( implode( ' + ', $v_description_array ) );
+
+					// Add to vulnerabilities array for table output.
+					array_push(
 						$vulnerabilities,
-						array( 'Version', 'Vulnerability information' )
+						array(
+							'name'        => $v_name,
+							'version'     => $v_version,
+							'fixed'       => $v_fixed,
+							'closed'      => $v_closed,
+							'score'       => $v_score,
+							'severity'    => $v_severity,
+							'description' => $v_description,
+						)
 					);
 				}
 			}
-		}
 
-		if ( 'json' === $format ) {
+			// Format and output the vulnerabilities in a table.
+			WP_CLI\Utils\format_items(
+				'table',
+				$vulnerabilities,
+				array( 'name', 'version', 'fixed', 'closed', 'score', 'severity', 'description' )
+			);
+
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in a JSON.
 			echo wp_json_encode( $plugins_complete );
 		}
 	}
+
 
 	/**
 	 * Theme section in WP-CLI command

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -624,226 +624,246 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	}
 
 	/**
-	 * Apache HTTPD section in WP-CLI command
+	 * Apache HTTPD section in WP-CLI command.
+	 *
+	 * This function handles the Apache HTTPD vulnerabilities section in the WP-CLI command.
+	 * It validates the format (table or json), retrieves Apache HTTPD vulnerabilities, and
+	 * outputs the information in the specified format.
 	 *
 	 * @since 3.2.0
 	 *
+	 * @param array  $args   Arguments passed to the command.
+	 * @param string $format The format for the output, either 'table' or 'json'.
+	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_apache() {
+	function wpvulnerability_cli_apache( $args, $format ) {
+
+		// Validate the format.
+		switch ( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+		}
 
 		$apache_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'apache' ) ) {
-
 			// Get Apache HTTPD vulnerabilities.
 			$apache_vulnerabilities = wpvulnerability_apache_get_vulnerabilities();
-
 		}
+
+		$apache_complete = array();
+		$vulnerabilities = array();
 
 		if ( isset( $apache_vulnerabilities['vulnerabilities'] ) ) {
 
 			$webserver = wpvulnerability_detect_webserver();
+
 			if ( isset( $webserver['id'] ) && 'apache' === $webserver['id'] && isset( $webserver['version'] ) && $webserver['version'] ) {
-				// Get the Apache HTTPD version.
-				$apache_version = wp_kses( (string) $webserver['version'], 'strip' );
-				$name           = wp_kses( wpvulnerability_sanitize_version_apache( (string) $apache_version ), 'strip' );
 
-				// Output the PHP name with red color.
-				WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
-
-				// Prepare the vulnerabilities array for table format output.
-				$vulnerabilities = array();
-
-				// Loop through each PHP vulnerability.
+				// Loop through each Apache vulnerability.
 				foreach ( $apache_vulnerabilities['vulnerabilities'] as $apache ) {
 
-					// Add the vulnerability details to the array.
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => trim( html_entity_decode( wp_kses( (string) $apache['versions'], 'strip' ) ) ),
-							'Vulnerability information' => '[*] ' . trim( html_entity_decode( wp_kses( (string) $apache['name'], 'strip' ) ) ),
-						)
-					);
-					if ( (int) $apache['unfixed'] ) {
+					$apache_complete_temp = array();
 
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => '*** ' . __( 'This vulnerability appears to be unpatched. Stay tuned for upcoming theme updates.', 'wpvulnerability' ) . ' ***',
-							)
-						);
+					$apache_complete_temp['version']  = trim( html_entity_decode( wp_kses( (string) $apache['version'], 'strip' ) ) );
+					$apache_complete_temp['affected'] = trim( html_entity_decode( wp_kses( (string) $apache['versions'], 'strip' ) ) );
+					$apache_complete_temp['unfixed']  = (int) $apache['unfixed'];
 
-					}
-
+					// Process vulnerability sources.
+					$apache_complete_temp['source'] = array();
 					if ( isset( $apache['source'] ) && count( $apache['source'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $apache['source'] as $vulnerability_source ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
-								)
+							$apache_complete_temp['source'][] = array(
+								'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
+								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
+								'link'        => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
 							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
-								)
-							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => ' ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-								)
-							);
-
 						}
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 					}
+
+					$apache_complete[] = $apache_complete_temp;
+					unset( $apache_complete_temp, $apache );
+
 				}
+			}
+		}
+
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
+
+			foreach ( $apache_complete as $a_vuln ) {
+				$v_version  = $a_vuln['version'];
+				$v_affected = $a_vuln['affected'];
+
+				// Determine if vulnerability is fixed.
+				switch ( $a_vuln['unfixed'] ) {
+					default:
+					case 0:
+						$v_fixed = 'yes';
+						break;
+					case 1:
+						$v_fixed = 'no';
+						break;
+				}
+
+				// Compile source descriptions.
+				$v_description_array = array();
+				foreach ( $a_vuln['source'] as $a_source ) {
+					$v_description_array[] = $a_source['name'] . ': ' . $a_source['description'];
+				}
+				$v_description = trim( implode( ' + ', $v_description_array ) );
+
+				// Add to vulnerabilities array for table output.
+				array_push(
+					$vulnerabilities,
+					array(
+						'version'     => $v_version,
+						'affected'    => $v_affected,
+						'fixed'       => $v_fixed,
+						'description' => $v_description,
+					)
+				);
 			}
 
 			// Format and output the vulnerabilities in a table.
 			WP_CLI\Utils\format_items(
 				'table',
 				$vulnerabilities,
-				array( 'Version', 'Vulnerability information' )
+				array( 'version', 'affected', 'fixed', 'description' )
 			);
 
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in JSON.
+			echo wp_json_encode( $apache_complete );
 		}
 	}
 
 	/**
-	 * Nginx section in WP-CLI command
+	 * Nginx section in WP-CLI command.
+	 *
+	 * This function handles the Nginx vulnerabilities section in the WP-CLI command.
+	 * It validates the format (table or json), retrieves Nginx vulnerabilities, and
+	 * outputs the information in the specified format.
 	 *
 	 * @since 3.2.0
 	 *
+	 * @param array  $args   Arguments passed to the command.
+	 * @param string $format The format for the output, either 'table' or 'json'.
+	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_nginx() {
+	function wpvulnerability_cli_nginx( $args, $format ) {
+
+		// Validate the format.
+		switch ( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+		}
 
 		$nginx_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'nginx' ) ) {
-
 			// Get nginx vulnerabilities.
 			$nginx_vulnerabilities = wpvulnerability_nginx_get_vulnerabilities();
-
 		}
+
+		$nginx_complete  = array();
+		$vulnerabilities = array();
 
 		if ( isset( $nginx_vulnerabilities['vulnerabilities'] ) ) {
 
 			$webserver = wpvulnerability_detect_webserver();
+
 			if ( isset( $webserver['id'] ) && 'nginx' === $webserver['id'] && isset( $webserver['version'] ) && $webserver['version'] ) {
-				// Get the nginx version.
-				$nginx_version = wp_kses( (string) $webserver['version'], 'strip' );
-				$name          = wp_kses( wpvulnerability_sanitize_version_nginx( (string) $nginx_version ), 'strip' );
 
-				// Output the PHP name with red color.
-				WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
-
-				// Prepare the vulnerabilities array for table format output.
-				$vulnerabilities = array();
-
-				// Loop through each PHP vulnerability.
+				// Loop through each Nginx vulnerability.
 				foreach ( $nginx_vulnerabilities['vulnerabilities'] as $nginx ) {
 
-					// Add the vulnerability details to the array.
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => trim( html_entity_decode( wp_kses( (string) $nginx['versions'], 'strip' ) ) ),
-							'Vulnerability information' => '[*] ' . trim( html_entity_decode( wp_kses( (string) $nginx['name'], 'strip' ) ) ),
-						)
-					);
-					if ( (int) $nginx['unfixed'] ) {
+					$nginx_complete_temp = array();
 
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => '*** ' . __( 'This vulnerability appears to be unpatched. Stay tuned for upcoming theme updates.', 'wpvulnerability' ) . ' ***',
-							)
-						);
+					$nginx_complete_temp['version']  = trim( html_entity_decode( wp_kses( (string) $nginx['version'], 'strip' ) ) );
+					$nginx_complete_temp['affected'] = trim( html_entity_decode( wp_kses( (string) $nginx['versions'], 'strip' ) ) );
+					$nginx_complete_temp['unfixed']  = (int) $nginx['unfixed'];
 
-					}
-
+					// Process vulnerability sources.
+					$nginx_complete_temp['source'] = array();
 					if ( isset( $nginx['source'] ) && count( $nginx['source'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $nginx['source'] as $vulnerability_source ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
-								)
+							$nginx_complete_temp['source'][] = array(
+								'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
+								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
+								'link'        => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
 							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
-								)
-							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => ' ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-								)
-							);
-
 						}
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 					}
+
+					$nginx_complete[] = $nginx_complete_temp;
+					unset( $nginx_complete_temp, $nginx );
+
 				}
+			}
+		}
+
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
+
+			foreach ( $nginx_complete as $n_vuln ) {
+				$v_version  = $n_vuln['version'];
+				$v_affected = $n_vuln['affected'];
+
+				// Determine if vulnerability is fixed.
+				switch ( $n_vuln['unfixed'] ) {
+					default:
+					case 0:
+						$v_fixed = 'yes';
+						break;
+					case 1:
+						$v_fixed = 'no';
+						break;
+				}
+
+				// Compile source descriptions.
+				$v_description_array = array();
+				foreach ( $n_vuln['source'] as $n_source ) {
+					$v_description_array[] = $n_source['name'] . ': ' . $n_source['description'];
+				}
+				$v_description = trim( implode( ' + ', $v_description_array ) );
+
+				// Add to vulnerabilities array for table output.
+				array_push(
+					$vulnerabilities,
+					array(
+						'version'     => $v_version,
+						'affected'    => $v_affected,
+						'fixed'       => $v_fixed,
+						'description' => $v_description,
+					)
+				);
 			}
 
 			// Format and output the vulnerabilities in a table.
 			WP_CLI\Utils\format_items(
 				'table',
 				$vulnerabilities,
-				array( 'Version', 'Vulnerability information' )
+				array( 'version', 'affected', 'fixed', 'description' )
 			);
 
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in JSON.
+			echo wp_json_encode( $nginx_complete );
 		}
 	}
 

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -183,7 +183,19 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_plugins() {
+	function wpvulnerability_cli_plugins( $args, $format ) {
+
+		switch( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+		}
 
 		$plugin_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'plugins' ) ) {
@@ -193,15 +205,21 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 		}
 
+		$plugins_complete = array();
+
 		// Loop through each plugin vulnerability.
 		foreach ( $plugin_vulnerabilities as $plugin ) {
 
 			if ( 1 === $plugin['vulnerable'] ) {
 
+				$plugins_complete[] = $plugin;
+
 				$name = trim( html_entity_decode( wp_kses( (string) $plugin['Name'], 'strip' ) ) );
 
-				// Output the plugin name with red color.
-				WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
+				if( 'table' === $format ) {
+					// Output the plugin name with red color.
+					WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
+				}
 
 				// Prepare the vulnerabilities array for table format output.
 				$vulnerabilities = array();
@@ -356,205 +374,197 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 				}
 
-				// Format and output the vulnerabilities in a table.
-				WP_CLI\Utils\format_items(
-					'table',
-					$vulnerabilities,
-					array( 'Version', 'Vulnerability information' )
-				);
-
+				if( 'table' === $format ) {
+					// Format and output the vulnerabilities in a table.
+					WP_CLI\Utils\format_items(
+						'table',
+						$vulnerabilities,
+						array( 'Version', 'Vulnerability information' )
+					);
+				}
 			}
 		}
+
+		if( 'json' === $format ) {
+			echo json_encode( $plugins_complete );
+		}
+
 	}
 
 	/**
 	 * Theme section in WP-CLI command
 	 *
+	 * This function retrieves and displays theme vulnerabilities
+	 * based on the specified format (table or JSON).
+	 *
 	 * @since 2.0.0
+	 *
+	 * @param array  $args   The arguments passed from the command line.
+	 * @param string $format The format for the output.
 	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_themes() {
+	function wpvulnerability_cli_themes( $args, $format ) {
+
+    // Validate the format
+    switch( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+    }
 
 		$theme_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'themes' ) ) {
-
-			// Get theme vulnerabilities.
+			// Get theme vulnerabilities
 			$theme_vulnerabilities = wpvulnerability_theme_get_vulnerabilities();
+    }
 
-		}
+		$themes_complete = array();
+		$vulnerabilities = array();
 
-		// Loop through each theme vulnerability.
+		// Loop through each theme vulnerability
 		foreach ( $theme_vulnerabilities as $theme ) {
 
 			if ( 1 === $theme['wpvulnerability']['vulnerable'] ) {
 
-				$name = trim( html_entity_decode( wp_kses( (string) $theme['wpvulnerability']['name'], 'strip' ) ) );
+				$themes_complete_temp = array();
+				$themes_complete_temp_vulnerabilities = array();
 
-				// Output the theme name with red color.
-				WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
+				// Process theme name and slug
+				$themes_complete_temp['name'] = trim( html_entity_decode( wp_kses( (string) $theme['wpvulnerability']['name'], 'strip' ) ) );
+				$themes_complete_temp['slug'] = trim( html_entity_decode( wp_kses( (string) $theme['wpvulnerability']['slug'], 'strip' ) ) );
 
-				// Prepare the vulnerabilities array for table format output.
-				$vulnerabilities = array();
+				// Prepare the vulnerabilities array for table format output
 				foreach ( $theme['wpvulnerability']['vulnerabilities'] as $vulnerability ) {
 
-					$severity = null;
+					// Process vulnerability severity
+					$themes_complete_temp_vulnerabilities['severity'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+						$themes_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					// Add the vulnerability details to the array.
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => trim( html_entity_decode( wp_kses( (string) $vulnerability['versions'], 'strip' ) ) ),
-							'Vulnerability information' => '[*] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) ),
-						)
-					);
-					if ( (int) $vulnerability['closed'] || (int) $vulnerability['unfixed'] ) {
-						if ( (int) $vulnerability['closed'] ) {
+					// Process vulnerability details
+					$themes_complete_temp_vulnerabilities['version'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['versions'], 'strip' ) ) );
+					$themes_complete_temp_vulnerabilities['name'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) );
+					$themes_complete_temp_vulnerabilities['closed'] = (int) $vulnerability['closed'];
+					$themes_complete_temp_vulnerabilities['unfixed'] = (int) $vulnerability['unfixed'];
 
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '*** ' . __( 'This theme is closed. Please replace it with another.', 'wpvulnerability' ) . ' ***',
-								)
-							);
-
-						}
-						if ( (int) $vulnerability['unfixed'] ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '*** ' . __( 'This vulnerability appears to be unpatched. Stay tuned for upcoming theme updates.', 'wpvulnerability' ) . ' ***',
-								)
-							);
-
-						}
-					}
-
-					$what = array();
+					// Process CWE details
+					$themes_complete_temp_vulnerabilities['cwe'] = array();
 					if ( isset( $vulnerability['impact']['cwe'] ) && count( $vulnerability['impact']['cwe'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $vulnerability['impact']['cwe'] as $vulnerability_cwe ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
-								)
+							$themes_complete_temp_vulnerabilities['cwe'][] = array( 
+								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ), 
+								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ) 
 							);
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
-								)
-							);
-
 						}
 					}
 
-					$score = null;
+					// Process CVSS score
+					$themes_complete_temp_vulnerabilities['score'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['score'] ) ) {
-						$score = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
+						$themes_complete_temp_vulnerabilities['score'] = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
 					}
-					$severity = null;
+					$themes_complete_temp_vulnerabilities['severity'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-						$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+						$themes_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					if ( ! is_null( $score ) || ! is_null( $severity ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
-						if ( ! is_null( $score ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10',
-								)
-							);
-						}
-						if ( ! is_null( $severity ) ) {
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => __( 'Severity: ', 'wpvulnerability' ) . $severity,
-								)
-							);
-						}
-					}
-
+					// Process vulnerability sources
+					$themes_complete_temp_vulnerabilities['source'] = array();
 					if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ',
-							)
-						);
-
 						foreach ( $vulnerability['source'] as $vulnerability_source ) {
-
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
-								)
+							$themes_complete_temp_vulnerabilities['source'][] = array( 
+								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ), 
+								'link' => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ) 
 							);
-							array_push(
-								$vulnerabilities,
-								array(
-									'Version' => ' ',
-									'Vulnerability information' => ' ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-								)
-							);
-
 						}
 					}
 
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
+					$themes_complete_temp['vulnerabilities'][] = $themes_complete_temp_vulnerabilities;
+					unset( $themes_complete_temp_vulnerabilities, $vulnerability );
 				}
 
-				// Format and output the vulnerabilities in a table.
-				WP_CLI\Utils\format_items(
-					'table',
-					$vulnerabilities,
-					array( 'Version', 'Vulnerability information' )
-				);
-
+				$themes_complete[] = $themes_complete_temp;
+				unset( $themes_complete_temp );
 			}
+			unset( $theme );
+    }
+
+    // Format output based on the selected format
+    if( 'table' === $format ) {
+
+			foreach( $themes_complete as $t_vuln ) {
+				$v_name = $t_vuln['slug'];
+
+				foreach( $t_vuln['vulnerabilities'] as $t_vul ) {
+
+					$v_version = $t_vul['version'];
+
+					// Determine if vulnerability is fixed
+					switch( $t_vul['unfixed'] ) {
+						default:
+						case 0:
+							$v_fixed = 'yes';
+							break;
+						case 1:
+							$v_fixed = 'no';
+							break;
+					}
+
+						// Determine if theme is closed
+					switch( $t_vul['closed'] ) {
+						default:
+						case 0:
+							$v_closed = 'no';
+							break;
+						case 1:
+							$v_closed = 'yes';
+							break;
+					}
+					$v_score = $t_vul['score'];
+					$v_severity = $t_vul['severity'];
+
+					// Compile CWE descriptions
+					$v_description_array = array();
+					foreach( $t_vul['cwe'] as $t_cwe ) {
+						if( isset( $t_cwe['name'] ) ) {
+							$v_description_array[] = $t_cwe['name'];
+						}
+					}
+					$v_description = trim( implode( ' + ', $v_description_array ) );
+
+						// Add to vulnerabilities array for table output
+					array_push(
+						$vulnerabilities,
+						array(
+							'name' => $v_name,
+							'version' => $v_version,
+							'fixed' => $v_fixed,
+							'closed' => $v_closed,
+							'score' => $v_score,
+							'severity' => $v_severity,
+							'description' => $v_description
+						)
+					);
+				}
+			}
+
+			// Format and output the vulnerabilities in a table
+			WP_CLI\Utils\format_items(
+				'table',
+				$vulnerabilities,
+				array( 'name', 'version', 'fixed', 'closed', 'score', 'severity', 'description' )
+			);
+
+		} elseif( 'json' === $format ) {
+			echo json_encode( $themes_complete );
 		}
 	}
 
@@ -895,31 +905,34 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 * @param array $args The subcommand to execute.
 	 * @return void
 	 */
-	function wpvulnerability_cli_command( $args ) {
+	function wpvulnerability_cli_command( $args, $assoc_args ) {
+
+		$subcommand = $args[0];
+		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';		
 
 		// Selects the correct function to execute based on the subcommand.
-		switch ( $args[0] ) {
+		switch ( $subcommand ) {
 			case 'core':
-				wpvulnerability_cli_core();
+				wpvulnerability_cli_core( $args, $format );
 				break;
 			case 'plugins':
-				wpvulnerability_cli_plugins();
+				wpvulnerability_cli_plugins( $args, $format );
 				break;
 			case 'themes':
-				wpvulnerability_cli_themes();
+				wpvulnerability_cli_themes( $args, $format );
 				break;
 			case 'php':
-				wpvulnerability_cli_php();
+				wpvulnerability_cli_php( $args, $format );
 				break;
 			case 'apache':
-				wpvulnerability_cli_apache();
+				wpvulnerability_cli_apache( $args, $format );
 				break;
 			case 'nginx':
-				wpvulnerability_cli_nginx();
+				wpvulnerability_cli_nginx( $args, $format );
 				break;
 			default:
 				// Displays an error message for an invalid subcommand.
-				WP_CLI::error( "'$args[0]' is not a registered subcommand of 'wpvulnerability'.\nAvailable subcommands: core, plugins, themes, php, apache, nginx" );
+				WP_CLI::error( "'$subcommand' is not a registered subcommand of 'wpvulnerability'.\nAvailable subcommands: core, plugins, themes, php, apache, nginx" );
 				break;
 		}
 	}
@@ -948,6 +961,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					'name'        => 'subcommand',
 					'description' => 'subcommand [core|plugins|themes|php|apache|nginx].',
 					'optional'    => false,
+				),
+				array(
+					'type'        => 'assoc',
+					'name'        => 'format',
+					'description' => 'Format for the output [table|json].',
+					'optional'    => true,
+					'default'     => 'table',
 				),
 			),
 			'when'      => 'after_wp_load',

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -185,7 +185,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 */
 	function wpvulnerability_cli_plugins( $args, $format ) {
 
-		switch( $format ) {
+		switch ( $format ) {
 			case 'table':
 				$format = 'table';
 				break;
@@ -216,7 +216,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 				$name = trim( html_entity_decode( wp_kses( (string) $plugin['Name'], 'strip' ) ) );
 
-				if( 'table' === $format ) {
+				if ( 'table' === $format ) {
 					// Output the plugin name with red color.
 					WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
 				}
@@ -374,7 +374,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 				}
 
-				if( 'table' === $format ) {
+				if ( 'table' === $format ) {
 					// Format and output the vulnerabilities in a table.
 					WP_CLI\Utils\format_items(
 						'table',
@@ -385,10 +385,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			}
 		}
 
-		if( 'json' === $format ) {
-			echo json_encode( $plugins_complete );
+		if ( 'json' === $format ) {
+			echo wp_json_encode( $plugins_complete );
 		}
-
 	}
 
 	/**
@@ -406,8 +405,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 */
 	function wpvulnerability_cli_themes( $args, $format ) {
 
-    // Validate the format
-    switch( $format ) {
+		// Validate the format.
+		switch ( $format ) {
 			case 'table':
 				$format = 'table';
 				break;
@@ -417,56 +416,56 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			default:
 				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
 				break;
-    }
+		}
 
 		$theme_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'themes' ) ) {
-			// Get theme vulnerabilities
+			// Get theme vulnerabilities.
 			$theme_vulnerabilities = wpvulnerability_theme_get_vulnerabilities();
-    }
+		}
 
 		$themes_complete = array();
 		$vulnerabilities = array();
 
-		// Loop through each theme vulnerability
+		// Loop through each theme vulnerability.
 		foreach ( $theme_vulnerabilities as $theme ) {
 
 			if ( 1 === $theme['wpvulnerability']['vulnerable'] ) {
 
-				$themes_complete_temp = array();
+				$themes_complete_temp                 = array();
 				$themes_complete_temp_vulnerabilities = array();
 
-				// Process theme name and slug
+				// Process theme name and slug.
 				$themes_complete_temp['name'] = trim( html_entity_decode( wp_kses( (string) $theme['wpvulnerability']['name'], 'strip' ) ) );
 				$themes_complete_temp['slug'] = trim( html_entity_decode( wp_kses( (string) $theme['wpvulnerability']['slug'], 'strip' ) ) );
 
-				// Prepare the vulnerabilities array for table format output
+				// Prepare the vulnerabilities array for table format output.
 				foreach ( $theme['wpvulnerability']['vulnerabilities'] as $vulnerability ) {
 
-					// Process vulnerability severity
+					// Process vulnerability severity.
 					$themes_complete_temp_vulnerabilities['severity'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
 						$themes_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					// Process vulnerability details
+					// Process vulnerability details.
 					$themes_complete_temp_vulnerabilities['version'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['versions'], 'strip' ) ) );
-					$themes_complete_temp_vulnerabilities['name'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) );
-					$themes_complete_temp_vulnerabilities['closed'] = (int) $vulnerability['closed'];
+					$themes_complete_temp_vulnerabilities['name']    = trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) );
+					$themes_complete_temp_vulnerabilities['closed']  = (int) $vulnerability['closed'];
 					$themes_complete_temp_vulnerabilities['unfixed'] = (int) $vulnerability['unfixed'];
 
-					// Process CWE details
+					// Process CWE details.
 					$themes_complete_temp_vulnerabilities['cwe'] = array();
 					if ( isset( $vulnerability['impact']['cwe'] ) && count( $vulnerability['impact']['cwe'] ) ) {
 						foreach ( $vulnerability['impact']['cwe'] as $vulnerability_cwe ) {
-							$themes_complete_temp_vulnerabilities['cwe'][] = array( 
-								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ), 
-								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ) 
+							$themes_complete_temp_vulnerabilities['cwe'][] = array(
+								'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
+								'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
 							);
 						}
 					}
 
-					// Process CVSS score
+					// Process CVSS score.
 					$themes_complete_temp_vulnerabilities['score'] = null;
 					if ( isset( $vulnerability['impact']['cvss']['score'] ) ) {
 						$themes_complete_temp_vulnerabilities['score'] = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
@@ -476,13 +475,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 						$themes_complete_temp_vulnerabilities['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 					}
 
-					// Process vulnerability sources
+					// Process vulnerability sources.
 					$themes_complete_temp_vulnerabilities['source'] = array();
 					if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {
 						foreach ( $vulnerability['source'] as $vulnerability_source ) {
-							$themes_complete_temp_vulnerabilities['source'][] = array( 
-								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ), 
-								'link' => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ) 
+							$themes_complete_temp_vulnerabilities['source'][] = array(
+								'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
+								'link' => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
 							);
 						}
 					}
@@ -495,20 +494,20 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				unset( $themes_complete_temp );
 			}
 			unset( $theme );
-    }
+		}
 
-    // Format output based on the selected format
-    if( 'table' === $format ) {
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
 
-			foreach( $themes_complete as $t_vuln ) {
+			foreach ( $themes_complete as $t_vuln ) {
 				$v_name = $t_vuln['slug'];
 
-				foreach( $t_vuln['vulnerabilities'] as $t_vul ) {
+				foreach ( $t_vuln['vulnerabilities'] as $t_vul ) {
 
 					$v_version = $t_vul['version'];
 
-					// Determine if vulnerability is fixed
-					switch( $t_vul['unfixed'] ) {
+					// Determine if vulnerability is fixed.
+					switch ( $t_vul['unfixed'] ) {
 						default:
 						case 0:
 							$v_fixed = 'yes';
@@ -518,8 +517,8 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 							break;
 					}
 
-						// Determine if theme is closed
-					switch( $t_vul['closed'] ) {
+					// Determine if theme is closed.
+					switch ( $t_vul['closed'] ) {
 						default:
 						case 0:
 							$v_closed = 'no';
@@ -528,43 +527,44 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 							$v_closed = 'yes';
 							break;
 					}
-					$v_score = $t_vul['score'];
+					$v_score    = $t_vul['score'];
 					$v_severity = $t_vul['severity'];
 
-					// Compile CWE descriptions
+					// Compile CWE descriptions.
 					$v_description_array = array();
-					foreach( $t_vul['cwe'] as $t_cwe ) {
-						if( isset( $t_cwe['name'] ) ) {
+					foreach ( $t_vul['cwe'] as $t_cwe ) {
+						if ( isset( $t_cwe['name'] ) ) {
 							$v_description_array[] = $t_cwe['name'];
 						}
 					}
 					$v_description = trim( implode( ' + ', $v_description_array ) );
 
-						// Add to vulnerabilities array for table output
+					// Add to vulnerabilities array for table output.
 					array_push(
 						$vulnerabilities,
 						array(
-							'name' => $v_name,
-							'version' => $v_version,
-							'fixed' => $v_fixed,
-							'closed' => $v_closed,
-							'score' => $v_score,
-							'severity' => $v_severity,
-							'description' => $v_description
+							'name'        => $v_name,
+							'version'     => $v_version,
+							'fixed'       => $v_fixed,
+							'closed'      => $v_closed,
+							'score'       => $v_score,
+							'severity'    => $v_severity,
+							'description' => $v_description,
 						)
 					);
 				}
 			}
 
-			// Format and output the vulnerabilities in a table
+			// Format and output the vulnerabilities in a table.
 			WP_CLI\Utils\format_items(
 				'table',
 				$vulnerabilities,
 				array( 'name', 'version', 'fixed', 'closed', 'score', 'severity', 'description' )
 			);
 
-		} elseif( 'json' === $format ) {
-			echo json_encode( $themes_complete );
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in a JSON.
+			echo wp_json_encode( $themes_complete );
 		}
 	}
 
@@ -902,13 +902,24 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	/**
 	 * Switches the command to show the list of vulnerabilities detected in the site.
 	 *
-	 * @param array $args The subcommand to execute.
+	 * This function acts as a dispatcher that selects and executes the appropriate
+	 * function based on the provided subcommand. It supports different output formats
+	 * such as table and JSON.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $args      The subcommand to execute.
+	 *                         Accepted values: 'core', 'plugins', 'themes', 'php', 'apache', 'nginx'.
+	 * @param array $assoc_args Associative arguments passed from the command line.
+	 *                          'format' (optional) - The format for the output. Defaults to 'table'.
+	 *                          Accepted values: 'table', 'json'.
+	 *
 	 * @return void
 	 */
 	function wpvulnerability_cli_command( $args, $assoc_args ) {
 
 		$subcommand = $args[0];
-		$format = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';		
+		$format     = isset( $assoc_args['format'] ) ? $assoc_args['format'] : 'table';
 
 		// Selects the correct function to execute based on the subcommand.
 		switch ( $subcommand ) {

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -213,7 +213,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		}
 
 		$plugins_complete = array();
-		$vulnerabilities = array();
+		$vulnerabilities  = array();
 
 		// Loop through each plugin vulnerability.
 		foreach ( $plugin_vulnerabilities as $plugin ) {

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -23,9 +23,25 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	 *
 	 * @since 2.0.0
 	 *
+	 * @param array  $args   Arguments passed to the command.
+	 * @param string $format The format for the output, either 'table' or 'json'.
+	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_core() {
+	function wpvulnerability_cli_core( $args, $format ) {
+
+		// Validate the format.
+		switch ( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+		}
 
 		$core_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'core' ) ) {
@@ -35,6 +51,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 		}
 
+		$core_complete   = array();
 		$vulnerabilities = array();
 
 		if ( $core_vulnerabilities && is_array( $core_vulnerabilities ) ) {
@@ -42,138 +59,92 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			// Loop through each core vulnerability.
 			foreach ( $core_vulnerabilities as $vulnerability ) {
 
-				$severity = null;
+				$core_complete_temp = array();
+
+				// Process theme name and slug.
+				$core_complete_temp['version'] = trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) );
+
+				// Process vulnerability severity.
+				$core_complete_temp['severity'] = null;
 				if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-					$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+					$core_complete_temp['severity'] = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
 				}
 
-				// Add the vulnerability details to the array.
-				array_push(
-					$vulnerabilities,
-					array(
-						'Version'                   => trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) ),
-						'Vulnerability information' => '[*] WordPress ' . trim( html_entity_decode( wp_kses( (string) $vulnerability['name'], 'strip' ) ) ),
-					)
-				);
-
-				$what = array();
+				// Process CWE details.
+				$core_complete_temp['cwe'] = array();
 				if ( isset( $vulnerability['impact']['cwe'] ) && count( $vulnerability['impact']['cwe'] ) ) {
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
 					foreach ( $vulnerability['impact']['cwe'] as $vulnerability_cwe ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
-							)
+						$core_complete_temp['cwe'][] = array(
+							'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['name'], 'strip' ) ) ),
+							'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
 						);
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_cwe['description'], 'strip' ) ) ),
-							)
-						);
-
 					}
 				}
 
-				$score = null;
+				// Process CVSS score.
+				$core_complete_temp['score'] = null;
 				if ( isset( $vulnerability['impact']['cvss']['score'] ) ) {
-					$score = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
-				}
-				$severity = null;
-				if ( isset( $vulnerability['impact']['cvss']['severity'] ) ) {
-					$severity = wpvulnerability_severity( $vulnerability['impact']['cvss']['severity'] );
+					$core_complete_temp['score'] = number_format( (float) $vulnerability['impact']['cvss']['score'], 1, '.', '' );
 				}
 
-				if ( ! is_null( $score ) || ! is_null( $severity ) ) {
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
-					if ( ! is_null( $score ) ) {
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => __( 'Global score: ', 'wpvulnerability' ) . $score . ' / 10',
-							)
-						);
-					}
-					if ( ! is_null( $severity ) ) {
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => __( 'Severity: ', 'wpvulnerability' ) . $severity,
-							)
-						);
-					}
-				}
-
+				// Process vulnerability sources.
+				$core_complete_temp['source'] = array();
 				if ( isset( $vulnerability['source'] ) && count( $vulnerability['source'] ) ) {
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
 					foreach ( $vulnerability['source'] as $vulnerability_source ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
-							)
+						$core_complete_temp['source'][] = array(
+							'name' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['name'], 'strip' ) ) ),
+							'link' => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
 						);
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => '    ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-							)
-						);
-
 					}
 				}
 
-				array_push(
-					$vulnerabilities,
-					array(
-						'Version'                   => ' ',
-						'Vulnerability information' => ' ',
-					)
-				);
-
+				$core_complete[] = $core_complete_temp;
+				unset( $core_complete_temp );
 			}
 		}
 
-		// Format and output the vulnerabilities in a table.
-		WP_CLI\Utils\format_items(
-			'table',
-			$vulnerabilities,
-			array( 'Version', 'Vulnerability information' )
-		);
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
+
+			foreach ( $core_complete as $c_vuln ) {
+
+				$v_version = $c_vuln['version'];
+
+				$v_score    = $c_vuln['score'];
+				$v_severity = $c_vuln['severity'];
+
+				// Compile CWE descriptions.
+				$v_description_array = array();
+				foreach ( $c_vuln['cwe'] as $c_cwe ) {
+					if ( isset( $c_cwe['name'] ) ) {
+						$v_description_array[] = $c_cwe['name'];
+					}
+				}
+				$v_description = trim( implode( ' + ', $v_description_array ) );
+
+				// Add to vulnerabilities array for table output.
+				array_push(
+					$vulnerabilities,
+					array(
+						'version'     => $v_version,
+						'score'       => $v_score,
+						'severity'    => $v_severity,
+						'description' => $v_description,
+					)
+				);
+			}
+
+			// Format and output the vulnerabilities in a table.
+			WP_CLI\Utils\format_items(
+				'table',
+				$vulnerabilities,
+				array( 'version', 'score', 'severity', 'description' )
+			);
+
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in JSON.
+			echo wp_json_encode( $core_complete );
+		}
 	}
 
 	/**
@@ -536,109 +507,119 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	}
 
 	/**
-	 * PHP section in WP-CLI command
+	 * PHP section in WP-CLI command.
+	 *
+	 * This function handles the PHP vulnerabilities section in the WP-CLI command.
+	 * It validates the format (table or json), retrieves PHP vulnerabilities, and
+	 * outputs the information in the specified format.
 	 *
 	 * @since 3.0.0
 	 *
+	 * @param array  $args   Arguments passed to the command.
+	 * @param string $format The format for the output, either 'table' or 'json'.
+	 *
 	 * @return void
 	 */
-	function wpvulnerability_cli_php() {
+	function wpvulnerability_cli_php( $args, $format ) {
+
+		// Validate the format.
+		switch ( $format ) {
+			case 'table':
+				$format = 'table';
+				break;
+			case 'json':
+				$format = 'json';
+				break;
+			default:
+				WP_CLI::error( "'$format' is not a valid format.\nAvailable formats: table, json" );
+				break;
+		}
 
 		$php_vulnerabilities = array();
 		if ( wpvulnerability_analyze_filter( 'php' ) ) {
-
 			// Get PHP vulnerabilities.
 			$php_vulnerabilities = wpvulnerability_php_get_vulnerabilities();
-
 		}
 
+		$php_complete    = array();
+		$vulnerabilities = array();
+
 		if ( isset( $php_vulnerabilities['vulnerabilities'] ) ) {
-
-			$name = wp_kses( wpvulnerability_sanitize_version_php( phpversion() ), 'strip' );
-
-			// Output the PHP name with red color.
-			WP_CLI::line( WP_CLI::colorize( "%r$name%n " ) );
-
-			// Prepare the vulnerabilities array for table format output.
-			$vulnerabilities = array();
 
 			// Loop through each PHP vulnerability.
 			foreach ( $php_vulnerabilities['vulnerabilities'] as $php ) {
 
-				// Add the vulnerability details to the array.
+				$php_complete_temp = array();
+
+				$php_complete_temp['version']  = trim( html_entity_decode( wp_kses( (string) $php['version'], 'strip' ) ) );
+				$php_complete_temp['affected'] = trim( html_entity_decode( wp_kses( (string) $php['versions'], 'strip' ) ) );
+				$php_complete_temp['unfixed']  = (int) $php['unfixed'];
+
+				// Process vulnerability sources.
+				$php_complete_temp['source'] = array();
+				if ( isset( $php['source'] ) && count( $php['source'] ) ) {
+					foreach ( $php['source'] as $vulnerability_source ) {
+						$php_complete_temp['source'][] = array(
+							'name'        => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
+							'description' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
+							'link'        => esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
+						);
+					}
+				}
+
+				$php_complete[] = $php_complete_temp;
+				unset( $php_complete_temp, $php );
+
+			}
+		}
+
+		// Format output based on the selected format.
+		if ( 'table' === $format ) {
+
+			foreach ( $php_complete as $p_vuln ) {
+				$v_version  = $p_vuln['version'];
+				$v_affected = $p_vuln['affected'];
+
+				// Determine if vulnerability is fixed.
+				switch ( $p_vuln['unfixed'] ) {
+					default:
+					case 0:
+						$v_fixed = 'yes';
+						break;
+					case 1:
+						$v_fixed = 'no';
+						break;
+				}
+
+				// Compile CWE descriptions.
+				$v_description_array = array();
+				foreach ( $p_vuln['source'] as $p_source ) {
+					$v_description_array[] = $p_source['name'] . ': ' . $p_source['description'];
+				}
+				$v_description = trim( implode( ' + ', $v_description_array ) );
+
+				// Add to vulnerabilities array for table output.
 				array_push(
 					$vulnerabilities,
 					array(
-						'Version'                   => trim( html_entity_decode( wp_kses( (string) $php['versions'], 'strip' ) ) ),
-						'Vulnerability information' => '[*] ' . trim( html_entity_decode( wp_kses( (string) $php['name'], 'strip' ) ) ),
+						'version'     => $v_version,
+						'affected'    => $v_affected,
+						'fixed'       => $v_fixed,
+						'description' => $v_description,
 					)
 				);
-				if ( (int) $php['unfixed'] ) {
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => '*** ' . __( 'This vulnerability appears to be unpatched. Stay tuned for upcoming theme updates.', 'wpvulnerability' ) . ' ***',
-						)
-					);
-
-				}
-
-				if ( isset( $php['source'] ) && count( $php['source'] ) ) {
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
-					foreach ( $php['source'] as $vulnerability_source ) {
-
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => '[+] ' . trim( html_entity_decode( wp_kses( (string) $vulnerability_source['id'], 'strip' ) ) ),
-							)
-						);
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => trim( html_entity_decode( wp_kses( (string) $vulnerability_source['description'], 'strip' ) ) ),
-							)
-						);
-						array_push(
-							$vulnerabilities,
-							array(
-								'Version' => ' ',
-								'Vulnerability information' => ' ' . esc_url_raw( (string) $vulnerability_source['link'], 'strip' ),
-							)
-						);
-
-					}
-
-					array_push(
-						$vulnerabilities,
-						array(
-							'Version'                   => ' ',
-							'Vulnerability information' => ' ',
-						)
-					);
-
-				}
 			}
 
 			// Format and output the vulnerabilities in a table.
 			WP_CLI\Utils\format_items(
 				'table',
 				$vulnerabilities,
-				array( 'Version', 'Vulnerability information' )
+				array( 'version', 'affected', 'fixed', 'description' )
 			);
 
+		} elseif ( 'json' === $format ) {
+			// Format and output the vulnerabilities in JSON.
+			echo wp_json_encode( $php_complete );
 		}
 	}
 

--- a/wpvulnerability-cli.php
+++ b/wpvulnerability-cli.php
@@ -179,7 +179,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	/**
 	 * Plugin section in WP-CLI command
 	 *
+	 * This function retrieves and displays plugin vulnerabilities
+	 * based on the specified format (table or JSON).
+	 *
 	 * @since 2.0.0
+	 *
+	 * @param array  $args   The arguments passed from the command line.
+	 * @param string $format The format for the output.
 	 *
 	 * @return void
 	 */

--- a/wpvulnerability-core.php
+++ b/wpvulnerability-core.php
@@ -177,16 +177,16 @@ function wpvulnerability_core_get_vulnerabilities() {
 
 	// Initialize variables.
 	$core_data_cache = null;
-	$core_data = null;
+	$core_data       = null;
 
 	if ( is_multisite() ) {
 		// Get the cached core data and decode it for multisite.
 		$core_data_cache = json_decode( get_site_option( 'wpvulnerability-core-cache' ) );
-		$core_data = json_decode( get_site_option( 'wpvulnerability-core' ), true );
+		$core_data       = json_decode( get_site_option( 'wpvulnerability-core' ), true );
 	} else {
 		// Get the cached core data and decode it for single site.
 		$core_data_cache = json_decode( get_option( 'wpvulnerability-core-cache' ) );
-		$core_data = json_decode( get_option( 'wpvulnerability-core' ), true );
+		$core_data       = json_decode( get_option( 'wpvulnerability-core' ), true );
 	}
 
 	// If the cache is stale or the core data is empty, update the cache.

--- a/wpvulnerability-core.php
+++ b/wpvulnerability-core.php
@@ -114,12 +114,12 @@ function wpvulnerability_get_fresh_core_vulnerabilities() {
 	$core_data = array();
 
 	// If no vulnerabilities are found, return false.
-	if ( empty( $response['data']['vulnerability'] ) ) {
+	if ( empty( $response ) ) {
 		return false;
 	}
 
 	// If vulnerabilities are found, update the core data.
-	foreach ( $response['data']['vulnerability'] as $v ) {
+	foreach ( $response as $v ) {
 		$core_data[] = array(
 			'name'   => wp_kses( (string) $v['name'], 'strip' ),
 			'source' => $v['source'],

--- a/wpvulnerability-core.php
+++ b/wpvulnerability-core.php
@@ -21,7 +21,7 @@ function wpvulnerability_core_info_after() {
 	// Retrieve the vulnerabilities for core from the options table and decode the JSON.
 	if ( is_multisite() ) {
 		$core_vulnerabilities = json_decode( get_site_option( 'wpvulnerability-core' ), true );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$core_vulnerabilities = json_decode( get_option( 'wpvulnerability-core' ), true );
 	}
 
@@ -97,61 +97,72 @@ function wpvulnerability_core_info_after() {
 }
 
 /**
- * Retrieves vulnerabilities for a given version and updates its data.
+ * Retrieves vulnerabilities for a given WordPress core version and updates its data.
  *
  * @since 2.0.0
  *
- * @return array The updated theme data array.
+ * @return array|false The updated core data array or false if no vulnerabilities are found.
  */
-function get_fresh_core_vulnerabilities() {
+function wpvulnerability_get_fresh_core_vulnerabilities() {
 
-	// Get the core version from the data.
+	// Get the core version and sanitize it.
 	$version = wpvulnerability_sanitize_version( get_bloginfo( 'version' ) );
 
-	// Retrieve vulnerabilities for the theme using its slug and version.
-	$response = wpvulnerability_get( 'core', $version );
+	// Retrieve vulnerabilities for the core version.
+	$response = wpvulnerability_get_core( $version, 0 );
 
 	$core_data = array();
 
+	// If no vulnerabilities are found, return false.
 	if ( empty( $response['data']['vulnerability'] ) ) {
 		return false;
 	}
 
-	// If vulnerabilities are found, update the data accordingly.
+	// If vulnerabilities are found, update the core data.
 	foreach ( $response['data']['vulnerability'] as $v ) {
-
 		$core_data[] = array(
 			'name'   => wp_kses( (string) $v['name'], 'strip' ),
 			'source' => $v['source'],
 			'impact' => $v['impact'],
 		);
-
 	}
+
 	return $core_data;
 }
 
 /**
  * Get Vulnerabilities
  *
+ * Retrieves and caches the vulnerabilities for the installed WordPress core version.
+ *
  * @since 2.0.0
  *
- * @return string JSON-encoded array of core data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of core data with vulnerabilities and vulnerable status.
  */
 function wpvulnerability_core_get_installed() {
 
 	$wpvulnerability_core_vulnerable = 0;
 
-	$core = get_fresh_core_vulnerabilities();
+	// Get fresh core vulnerabilities.
+	$core = wpvulnerability_get_fresh_core_vulnerabilities();
 
+	// Check if vulnerabilities were found and count them.
 	if ( is_array( $core ) && count( $core ) ) {
-
 		$wpvulnerability_core_vulnerable = count( $core );
-
 	}
 
-	update_option( 'wpvulnerability-core', wp_json_encode( $core ) );
-	update_option( 'wpvulnerability-core-vulnerable', wp_json_encode( number_format( $wpvulnerability_core_vulnerable, 0, '.', '' ) ) );
+	// Cache the vulnerability data and the timestamp for cache expiration.
+	if ( is_multisite() ) {
+		update_site_option( 'wpvulnerability-core', wp_json_encode( $core ) );
+		update_site_option( 'wpvulnerability-core-vulnerable', wp_json_encode( number_format( $wpvulnerability_core_vulnerable, 0, '.', '' ) ) );
+		update_site_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+	} else {
+		update_option( 'wpvulnerability-core', wp_json_encode( $core ) );
+		update_option( 'wpvulnerability-core-vulnerable', wp_json_encode( number_format( $wpvulnerability_core_vulnerable, 0, '.', '' ) ) );
+		update_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+	}
 
+	// Return the JSON-encoded array of core vulnerabilities.
 	return wp_json_encode( $core );
 }
 
@@ -164,46 +175,31 @@ function wpvulnerability_core_get_installed() {
  */
 function wpvulnerability_core_get_vulnerabilities() {
 
+	// Initialize variables.
+	$core_data_cache = null;
+	$core_data = null;
+
 	if ( is_multisite() ) {
-
-		// Get the cached core data and decode it.
+		// Get the cached core data and decode it for multisite.
 		$core_data_cache = json_decode( get_site_option( 'wpvulnerability-core-cache' ) );
-
-		// Get the core data and decode it.
 		$core_data = json_decode( get_site_option( 'wpvulnerability-core' ), true );
-
-	} elseif ( ! is_multisite() ) {
-
-		// Get the cached core data and decode it.
+	} else {
+		// Get the cached core data and decode it for single site.
 		$core_data_cache = json_decode( get_option( 'wpvulnerability-core-cache' ) );
-
-		// Get the core data and decode it.
 		$core_data = json_decode( get_option( 'wpvulnerability-core' ), true );
-
 	}
 
-	// If the cache is stale or the theme data is empty, update the cache.
+	// If the cache is stale or the core data is empty, update the cache.
 	if ( $core_data_cache < time() || empty( $core_data ) ) {
-
-		// Get the core data and update the cache.
 		$core_data = json_decode( wpvulnerability_core_get_installed(), true );
-
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
+	// Return the core data with vulnerabilities.
 	return $core_data;
 }
 
 /**
- * Update the core cache and remove any old cache data
+ * Update the core cache and remove any old cache data.
  *
  * @since 2.0.0
  *
@@ -213,17 +209,10 @@ function wpvulnerability_core_get_vulnerabilities_clean() {
 
 	// Update the core cache.
 	wpvulnerability_core_get_installed();
-
-	if ( is_multisite() ) {
-		update_site_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-	} elseif ( ! is_multisite() ) {
-		update_option( 'wpvulnerability-core-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-	}
 }
 
 /**
- * Admin Head
- * Adds vulnerability information after the core and notices
+ * Adds vulnerability information after the core version and notices on the update-core.php page.
  *
  * @since 2.0.0
  *
@@ -231,24 +220,16 @@ function wpvulnerability_core_get_vulnerabilities_clean() {
  */
 function wpvulnerability_core_page() {
 
-	// Check if the current page is the update core page.
+	// Check if the current page is the update-core.php page.
 	global $pagenow;
-	if (
-		wpvulnerability_analyze_filter( 'core' ) && 'update-core.php' === $pagenow &&
-		(
-			( is_multisite() && is_network_admin() && current_user_can( 'manage_network' ) ) ||
-			( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) )
-		)
-	) {
+	if ( wpvulnerability_analyze_filter( 'core' ) && 'update-core.php' === $pagenow && wpvulnerability_capabilities() ) {
 
 		// Get the vulnerabilities for the core.
 		$core = wpvulnerability_core_get_vulnerabilities();
 
-		// Loop through and add vulnerability information after the core version for vulnerabilities.
+		// If there are vulnerabilities, add an action to display them after the core auto updates settings.
 		if ( is_array( $core ) && count( $core ) ) {
-
 			add_action( 'after_core_auto_updates_settings', 'wpvulnerability_core_info_after' );
-
 		}
 	}
 }

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -187,6 +187,7 @@ function wpvulnerability_detect_webserver() {
 	// Normalize and set the web server ID based on the detected name.
 	if ( isset( $webserver['name'] ) && $webserver['name'] ) {
 		switch ( trim( strtolower( $webserver['name'] ) ) ) {
+			case 'httpd':
 			case 'apache':
 				$webserver['id']   = 'apache';
 				$webserver['name'] = 'Apache HTTPD'; // Provide a more readable name.

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -24,13 +24,11 @@ function wpvulnerability_capabilities() {
 
 	$user = wp_get_current_user();
 
-	// Check if the user has network admin or main site admin capabilities in a multisite setup
 	if ( ! ( is_multisite() && ( is_network_admin() || is_main_site() ) && current_user_can( 'manage_network' ) && is_super_admin( $user->ID ) ) ) {
+		// Check if the user has network admin or main site admin capabilities in a multisite setup.
 		return false;
-	}
-
-	// Check if the user has admin capabilities in a single site setup
-	elseif ( ! ( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) ) ) {
+	} elseif ( ! ( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) ) ) {
+		// Check if the user has admin capabilities in a single site setup.
 		return false;
 	}
 
@@ -260,7 +258,7 @@ function wpvulnerability_pretty_operator( $op ) {
 /**
  * Returns a human-readable severity level.
  *
- * This function takes a severity string and returns a human-readable 
+ * This function takes a severity string and returns a human-readable
  * severity level, localized for translation.
  *
  * @version 2.0.0
@@ -337,7 +335,7 @@ function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 		if ( empty( sanitize_title( $slug ) ) ) {
 			return false;
 		}
-	// Validate slug for core.
+		// Validate slug for core.
 	} elseif ( 'core' === $type ) {
 		if ( ! wpvulnerability_sanitize_version( $slug ) ) {
 			return false;
@@ -418,7 +416,7 @@ function wpvulnerability_get_core( $version = null, $cache = 1 ) {
 			'impact' => $v['impact'],
 		);
 	}
-	
+
 	return $vulnerability;
 }
 
@@ -494,7 +492,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 				}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+				// If the vulnerability has only a maximum version, check if the specified version is below that version.
 			} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 				if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -513,7 +511,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 				}
 
-			// If the vulnerability has only a minimum version, check if the specified version is above that version.
+				// If the vulnerability has only a minimum version, check if the specified version is above that version.
 			} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 				if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -595,7 +593,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is below the max operator.
+			// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -614,7 +612,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is above the min operator.
+			// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -784,7 +782,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is below the max operator.
+			// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -800,7 +798,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is above the min operator.
+			// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -894,7 +892,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is below the max operator.
+			// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -910,7 +908,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is above the min operator.
+			// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -1004,7 +1002,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is below the max operator.
+			// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -1020,7 +1018,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 
 			}
 
-		// Check if the version is above the min operator.
+			// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -12,25 +12,36 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 /**
  * Checks and validates user capabilities for managing vulnerability settings in a WordPress environment.
  *
- * This function verifies if the current user has the appropriate permissions to manage network settings in a multisite installation
- * or manage options in a single site installation. It is designed to be used in the context of a plugin or theme that interacts with
- * WordPress vulnerability settings.
+ * This function verifies if the current user has the appropriate permissions to manage network settings
+ * in a multisite installation or manage options in a single site installation. It is designed to be used
+ * in the context of a plugin or theme that interacts with WordPress vulnerability settings.
  *
  * @since 3.0.0
  *
- * @return bool Returns false if the current user does not have the required capabilities, void otherwise.
+ * @return bool Returns false if the current user does not have the required capabilities, true otherwise.
  */
 function wpvulnerability_capabilities() {
 
-	if ( ! ( is_multisite() && ( is_network_admin() || is_main_site() ) && current_user_can( 'manage_network' ) ) ) {
-		return false;
-	} elseif ( ! ( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) ) ) {
+	$user = wp_get_current_user();
+
+	// Check if the user has network admin or main site admin capabilities in a multisite setup
+	if ( ! ( is_multisite() && ( is_network_admin() || is_main_site() ) && current_user_can( 'manage_network' ) && is_super_admin( $user->ID ) ) ) {
 		return false;
 	}
+
+	// Check if the user has admin capabilities in a single site setup
+	elseif ( ! ( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
  * Sanitize a version string.
+ *
+ * This function removes any leading or trailing whitespace from the version string
+ * and strips out any non-alphanumeric characters except for hyphens, underscores, and dots.
  *
  * @version 2.0.0
  *
@@ -41,8 +52,10 @@ function wpvulnerability_capabilities() {
 function wpvulnerability_sanitize_version( $version ) {
 
 	// Remove any leading/trailing whitespace.
+	$version = trim( $version );
+
 	// Strip out any non-alphanumeric characters except for hyphens, underscores, and dots.
-	$version = trim( preg_replace( '/[^a-zA-Z0-9_\-.]+/', '', $version ) );
+	$version = preg_replace( '/[^a-zA-Z0-9_\-.]+/', '', $version );
 
 	return $version;
 }
@@ -62,6 +75,7 @@ function wpvulnerability_sanitize_version( $version ) {
  */
 function wpvulnerability_sanitize_version_php( $version ) {
 
+	// Sanitize the version string using the base sanitizer.
 	$version = wpvulnerability_sanitize_version( $version );
 
 	// Validate format (major.minor[.patch]) and sanitize.
@@ -89,6 +103,7 @@ function wpvulnerability_sanitize_version_php( $version ) {
  */
 function wpvulnerability_sanitize_version_apache( $version ) {
 
+	// Sanitize the version string using the base sanitizer.
 	$version = wpvulnerability_sanitize_version( $version );
 
 	// Validate format (major.minor[.patch]) and sanitize.
@@ -116,6 +131,7 @@ function wpvulnerability_sanitize_version_apache( $version ) {
  */
 function wpvulnerability_sanitize_version_nginx( $version ) {
 
+	// Sanitize the version string using the base sanitizer.
 	$version = wpvulnerability_sanitize_version( $version );
 
 	// Validate format (major.minor[.patch]) and sanitize.
@@ -181,7 +197,7 @@ function wpvulnerability_detect_webserver() {
 				$webserver['id']   = 'nginx'; // 'nginx' is both the ID and the readable name.
 				$webserver['name'] = 'nginx'; // Provide a more readable name.
 				break;
-			// Additional web servers will be added here.
+			// Additional web servers can be added here.
 		}
 	}
 
@@ -204,6 +220,9 @@ function wpvulnerability_detect_webserver() {
 
 /**
  * Returns a human-readable HTML entity for the given comparison operator.
+ *
+ * This function takes a comparison operator in string format and returns
+ * its corresponding HTML entity for better readability in web contexts.
  *
  * @version 2.0.0
  *
@@ -239,65 +258,37 @@ function wpvulnerability_pretty_operator( $op ) {
 }
 
 /**
- * Returns a human-readable HTML entity for the given comparison operator.
+ * Returns a human-readable severity level.
  *
- * @version 2.0.0
- *
- * @param string $op The operator string to prettify.
- *
- * @return string The pretty operator HTML string.
- */
-function wpvulnerability_pretty_operator_cli( $op ) {
-
-	switch ( trim( strtolower( $op ) ) ) {
-		// Less than.
-		case 'lt':
-			return '< ';
-		// Less than or equal to.
-		case 'le':
-			return '<= ';
-		// Greater than.
-		case 'gt':
-			return '> ';
-		// Greater than or equal to.
-		case 'ge':
-			return '>= ';
-		// Equal to.
-		case 'eq':
-			return '= ';
-		// Not equal to.
-		case 'ne':
-			return '!= ';
-		// Return the original operator if it's not recognized.
-		default:
-			return $op;
-	}
-}
-
-/**
- * Returns a Severity
+ * This function takes a severity string and returns a human-readable 
+ * severity level, localized for translation.
  *
  * @version 2.0.0
  *
  * @param string $severity The severity string to prettify.
  *
- * @return string The severity string.
+ * @return string The human-readable severity string.
  */
 function wpvulnerability_severity( $severity ) {
 
 	switch ( trim( strtolower( $severity ) ) ) {
+		// No severity.
 		case 'n':
 			/* translators: Severity: None */
 			return __( 'None', 'wpvulnerability' );
+		// Low severity.
 		case 'l':
 			/* translators: Severity: Low */
 			return __( 'Low', 'wpvulnerability' );
+		// Medium severity.
 		case 'm':
 			/* translators: Severity: Medium */
 			return __( 'Medium', 'wpvulnerability' );
+		// High severity.
 		case 'h':
 			/* translators: Severity: High */
 			return __( 'High', 'wpvulnerability' );
+		// Critical severity.
 		case 'c':
 			/* translators: Severity: Critical */
 			return __( 'Critical', 'wpvulnerability' );
@@ -310,10 +301,14 @@ function wpvulnerability_severity( $severity ) {
 /**
  * Retrieves vulnerabilities information from the API.
  *
+ * This function fetches vulnerability information based on the provided type and slug.
+ * It supports caching to minimize API requests and improve performance.
+ *
  * @version 2.0.0
  *
- * @param string $type The type of vulnerability. Can be 'core', 'plugin' or 'theme'.
- * @param string $slug The slug of the plugin or theme. For core vulnerabilities, it is the version string.
+ * @param string $type  The type of vulnerability. Can be 'core', 'plugin' or 'theme'.
+ * @param string $slug  The slug of the plugin or theme. For core vulnerabilities, it is the version string.
+ * @param int    $cache Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|bool An array with the vulnerability information or false if there's an error.
  */
@@ -337,14 +332,13 @@ function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 			break;
 	}
 
-	// Validate slug.
+	// Validate slug for plugin or theme.
 	if ( 'plugin' === $type || 'theme' === $type ) {
-
 		if ( empty( sanitize_title( $slug ) ) ) {
 			return false;
 		}
+	// Validate slug for core.
 	} elseif ( 'core' === $type ) {
-
 		if ( ! wpvulnerability_sanitize_version( $slug ) ) {
 			return false;
 		}
@@ -352,7 +346,7 @@ function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 
 	// Cache key.
 	$key = 'wpvulnerability_' . $type . '_' . $slug;
-	if( $cache ) {
+	if ( $cache ) {
 		if ( is_multisite() ) {
 			$vulnerability_data = get_site_transient( $key );
 		} else {
@@ -362,12 +356,10 @@ function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 
 	// If not cached, get the updated data.
 	if ( empty( $vulnerability_data ) ) {
-
 		$url      = WPVULNERABILITY_API_HOST . $type . '/' . $slug . '/';
 		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( ! is_wp_error( $response ) ) {
-
 			$body = wp_remote_retrieve_body( $response );
 			if ( is_multisite() ) {
 				set_site_transient( $key, $body, HOUR_IN_SECONDS * WPVULNERABILITY_CACHE_HOURS );
@@ -385,9 +377,14 @@ function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 /**
  * Retrieve vulnerabilities for a specific version of WordPress Core.
  *
+ * This function fetches vulnerability information for a given version of WordPress Core.
+ * If no version is provided, it retrieves vulnerabilities for the currently installed version.
+ * It supports caching to minimize API requests and improve performance.
+ *
  * @since 2.0.0
  *
  * @param string|null $version The version number of WordPress Core. If null, retrieves for the installed version.
+ * @param int         $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false Array of vulnerabilities, or false on error.
  */
@@ -414,15 +411,14 @@ function wpvulnerability_get_core( $version = null, $cache = 1 ) {
 	// Process vulnerabilities and return as an array.
 	$vulnerability = array();
 	foreach ( $response['data']['vulnerability'] as $v ) {
-
 		$vulnerability[] = array(
 			'name'   => wp_kses( (string) $v['name'], 'strip' ),
 			'link'   => esc_url_raw( (string) $v['link'] ),
 			'source' => $v['source'],
 			'impact' => $v['impact'],
 		);
-
 	}
+	
 	return $vulnerability;
 }
 
@@ -439,6 +435,7 @@ function wpvulnerability_get_core( $version = null, $cache = 1 ) {
  * @param string $slug    The slug of the plugin to check for vulnerabilities.
  * @param string $version The version of the plugin to check. The function may return `false` if this is invalid and `$data` is not set.
  * @param int    $data    Optional. Set to 1 to return general plugin data instead of vulnerabilities. Default 0 (return vulnerabilities).
+ * @param int    $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false An array of vulnerabilities or plugin data if `$data` is set to 1, or `false` if no vulnerabilities are found or the version number is invalid and `$data` is not set.
  */
@@ -462,7 +459,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 		if ( isset( $response['data'] ) ) {
 			$vulnerability = array(
-				'name'   => wp_kses( (string) (string) $response['data']['name'], 'strip' ),
+				'name'   => wp_kses( (string) $response['data']['name'], 'strip' ),
 				'link'   => esc_url( (string) $response['data']['link'] ),
 				'latest' => number_format( (int) $response['data']['latest'], 0, '.', '' ),
 				'closed' => number_format( (int) $response['data']['closed'], 0, '.', '' ),
@@ -497,7 +494,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 				}
 
-				// If the vulnerability has only a maximum version, check if the specified version is below that version.
+			// If the vulnerability has only a maximum version, check if the specified version is below that version.
 			} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 				if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -516,7 +513,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 				}
 
-				// If the vulnerability has a minimum version and maximum version, check if the specified version is within that range.
+			// If the vulnerability has only a minimum version, check if the specified version is above that version.
 			} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 				if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -544,19 +541,23 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 /**
  * Get vulnerabilities for a specific theme.
  *
+ * This function retrieves and sanitizes the theme slug and version before querying the vulnerability API.
+ * It returns an array of vulnerabilities if any are found, or false if there are none.
+ *
  * @since 2.0.0
  *
  * @param string $slug    Slug of the theme.
  * @param string $version Version of the theme.
+ * @param int    $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
 function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
-	// Sanitize the plugin slug.
+	// Sanitize the theme slug.
 	$slug = sanitize_title( $slug );
 
-	// Get the response from the vulnerability API.
+	// Validate the version number.
 	if ( ! wpvulnerability_sanitize_version( $version ) ) {
 		return false;
 	}
@@ -572,9 +573,10 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 		return false;
 	}
 
+	// Process each vulnerability.
 	foreach ( $response['data']['vulnerability'] as $v ) {
 
-		// If the vulnerability has minimum and maximum versions, check if the specified version falls within that range.
+		// Check if the version falls within the min and max operator range.
 		if ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] && isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) && version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -583,7 +585,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 				$vulnerability[] = array(
 					'name'        => wp_kses( (string) $v['name'], 'strip' ),
 					'description' => wp_kses_post( (string) $v['description'] ),
-					'versions'    => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
+					'versions'    => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
 					'version'     => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'     => (int) $v['operator']['unfixed'],
 					'closed'      => (int) $v['operator']['closed'],
@@ -593,7 +595,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -612,7 +614,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -621,7 +623,7 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 				$vulnerability[] = array(
 					'name'        => wp_kses( (string) $v['name'], 'strip' ),
 					'description' => wp_kses_post( (string) $v['description'] ),
-					'versions'    => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'], 'strip' ),
+					'versions'    => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'], 'strip' ),
 					'version'     => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'     => (int) $v['operator']['unfixed'],
 					'closed'      => (int) $v['operator']['closed'],
@@ -643,15 +645,17 @@ function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
  *
  * @since 2.0.0
  *
+ * @param int $cache Optional. Whether to use cache. Default is 1 (true).
+ *
  * @return array|false Returns an array with the statistical information if successful, false otherwise.
  */
 function wpvulnerability_get_statistics( $cache = 1 ) {
 
 	$vulnerability = null;
-	$key = 'wpvulnerability_stats';
+	$key           = 'wpvulnerability_stats';
 
 	// Get cached statistics if available.
-	if( $cache ) {
+	if ( $cache ) {
 		if ( is_multisite() ) {
 			$vulnerability = get_site_transient( $key );
 		} else {
@@ -662,8 +666,7 @@ function wpvulnerability_get_statistics( $cache = 1 ) {
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
 	if ( empty( $vulnerability ) ) {
 
-		$url = WPVULNERABILITY_API_HOST;
-		// Parse the JSON response into an associative array.
+		$url      = WPVULNERABILITY_API_HOST;
 		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( ! is_wp_error( $response ) ) {
@@ -711,20 +714,24 @@ function wpvulnerability_get_statistics( $cache = 1 ) {
 /**
  * Get vulnerabilities for a specific PHP version.
  *
+ * This function retrieves vulnerability data for a specified PHP version.
+ * It supports caching to minimize API requests and improve performance.
+ *
  * @since 3.0.0
  *
  * @param string $version PHP Version.
+ * @param int    $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
 function wpvulnerability_get_php( $version, $cache = 1 ) {
 
-	$key                  = 'wpvulnerability_php';
+	$key                = 'wpvulnerability_php';
 	$vulnerability_data = null;
-	$vulnerability       = array();
+	$vulnerability      = array();
 
 	// Get cached statistics if available.
-	if( $cache ) {
+	if ( $cache ) {
 		if ( is_multisite() ) {
 			$vulnerability_data = get_site_transient( $key );
 		} else {
@@ -735,8 +742,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
 	if ( empty( $vulnerability_data ) ) {
 
-		$url = WPVULNERABILITY_API_HOST . 'php/' . $version . '/';
-		// Parse the JSON response into an associative array.
+		$url      = WPVULNERABILITY_API_HOST . 'php/' . $version . '/';
 		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( ! is_wp_error( $response ) ) {
@@ -752,16 +758,17 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 		}
 	}
 
-	// If the response does not contain statistics, return false.
+	// If the response does not contain vulnerabilities, return false.
 	$response = json_decode( $vulnerability_data, true );
 
 	if ( ( isset( $response['error'] ) && $response['error'] ) || empty( $response['data']['vulnerability'] ) ) {
 		return false;
 	}
 
+	// Process each vulnerability.
 	foreach ( $response['data']['vulnerability'] as $v ) {
 
-		// If the vulnerability has minimum and maximum versions, check if the specified version falls within that range.
+		// Check if the version falls within the min and max operator range.
 		if ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] && isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) && version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -769,7 +776,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 				// Add the vulnerability to the list.
 				$vulnerability[] = array(
 					'name'     => wp_kses( (string) $v['name'], 'strip' ),
-					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
+					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
 					'version'  => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'  => (int) $v['operator']['unfixed'],
 					'source'   => $v['source'],
@@ -777,7 +784,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -793,7 +800,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -801,7 +808,7 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 				// Add the vulnerability to the list.
 				$vulnerability[] = array(
 					'name'     => wp_kses( (string) $v['name'], 'strip' ),
-					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'], 'strip' ),
+					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'], 'strip' ),
 					'version'  => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'  => (int) $v['operator']['unfixed'],
 					'source'   => $v['source'],
@@ -817,9 +824,13 @@ function wpvulnerability_get_php( $version, $cache = 1 ) {
 /**
  * Get vulnerabilities for a specific Apache HTTPD version.
  *
+ * This function retrieves vulnerability data for a specified Apache HTTPD version.
+ * It supports caching to minimize API requests and improve performance.
+ *
  * @since 3.2.0
  *
  * @param string $version Apache Version.
+ * @param int    $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
@@ -830,7 +841,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 	$vulnerability      = array();
 
 	// Get cached statistics if available.
-	if( $cache ) {
+	if ( $cache ) {
 		if ( is_multisite() ) {
 			$vulnerability_data = get_site_transient( $key );
 		} else {
@@ -841,8 +852,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
 	if ( empty( $vulnerability_data ) ) {
 
-		$url = WPVULNERABILITY_API_HOST . 'apache/' . $version . '/';
-		// Parse the JSON response into an associative array.
+		$url      = WPVULNERABILITY_API_HOST . 'apache/' . $version . '/';
 		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( ! is_wp_error( $response ) ) {
@@ -858,16 +868,17 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 		}
 	}
 
-	// If the response does not contain statistics, return false.
+	// If the response does not contain vulnerabilities, return false.
 	$response = json_decode( $vulnerability_data, true );
 
 	if ( ( isset( $response['error'] ) && $response['error'] ) || empty( $response['data']['vulnerability'] ) ) {
 		return false;
 	}
 
+	// Process each vulnerability.
 	foreach ( $response['data']['vulnerability'] as $v ) {
 
-		// If the vulnerability has minimum and maximum versions, check if the specified version falls within that range.
+		// Check if the version falls within the min and max operator range.
 		if ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] && isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) && version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -883,7 +894,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -899,7 +910,7 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -921,11 +932,15 @@ function wpvulnerability_get_apache( $version, $cache = 1 ) {
 }
 
 /**
- * Get vulnerabilities for a specific Apache HTTPD version.
+ * Get vulnerabilities for a specific nginx version.
+ *
+ * This function retrieves vulnerability data for a specified nginx version.
+ * It supports caching to minimize API requests and improve performance.
  *
  * @since 3.2.0
  *
- * @param string $version Apache Version.
+ * @param string $version nginx Version.
+ * @param int    $cache   Optional. Whether to use cache. Default is 1 (true).
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
@@ -936,7 +951,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 	$vulnerability      = array();
 
 	// Get cached statistics if available.
-	if( $cache ) {
+	if ( $cache ) {
 		if ( is_multisite() ) {
 			$vulnerability_data = get_site_transient( $key );
 		} else {
@@ -947,8 +962,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
 	if ( empty( $vulnerability_data ) ) {
 
-		$url = WPVULNERABILITY_API_HOST . 'nginx/' . $version . '/';
-		// Parse the JSON response into an associative array.
+		$url      = WPVULNERABILITY_API_HOST . 'nginx/' . $version . '/';
 		$response = wp_remote_get( $url, array( 'timeout' => 2500 ) );
 
 		if ( ! is_wp_error( $response ) ) {
@@ -964,16 +978,17 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 		}
 	}
 
-	// If the response does not contain statistics, return false.
+	// If the response does not contain vulnerabilities, return false.
 	$response = json_decode( $vulnerability_data, true );
 
 	if ( ( isset( $response['error'] ) && $response['error'] ) || empty( $response['data']['vulnerability'] ) ) {
 		return false;
 	}
 
+	// Process each vulnerability.
 	foreach ( $response['data']['vulnerability'] as $v ) {
 
-		// If the vulnerability has minimum and maximum versions, check if the specified version falls within that range.
+		// Check if the version falls within the min and max operator range.
 		if ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] && isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) && version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -981,7 +996,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 				// Add the vulnerability to the list.
 				$vulnerability[] = array(
 					'name'     => wp_kses( (string) $v['name'], 'strip' ),
-					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
+					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'] . ' - ' . wpvulnerability_pretty_operator( $v['operator']['max_operator'] ) . $v['operator']['max_version'], 'strip' ),
 					'version'  => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'  => (int) $v['operator']['unfixed'],
 					'source'   => $v['source'],
@@ -989,7 +1004,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is below the max operator.
 		} elseif ( isset( $v['operator']['max_operator'] ) && $v['operator']['max_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['max_version'], $v['operator']['max_operator'] ) ) {
@@ -1005,7 +1020,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 
 			}
 
-			// If the vulnerability has only a maximum version, check if the specified version is below that version.
+		// Check if the version is above the min operator.
 		} elseif ( isset( $v['operator']['min_operator'] ) && $v['operator']['min_operator'] ) {
 
 			if ( version_compare( $version, $v['operator']['min_version'], $v['operator']['min_operator'] ) ) {
@@ -1013,7 +1028,7 @@ function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 				// Add the vulnerability to the list.
 				$vulnerability[] = array(
 					'name'     => wp_kses( (string) $v['name'], 'strip' ),
-					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_version'] ) . $v['operator']['min_version'], 'strip' ),
+					'versions' => wp_kses( wpvulnerability_pretty_operator( $v['operator']['min_operator'] ) . $v['operator']['min_version'], 'strip' ),
 					'version'  => wp_kses( (string) $v['operator']['min_version'], 'strip' ),
 					'unfixed'  => (int) $v['operator']['unfixed'],
 					'source'   => $v['source'],

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -409,9 +409,22 @@ function wpvulnerability_get_core( $version = null, $cache = 1 ) {
 	// Process vulnerabilities and return as an array.
 	$vulnerability = array();
 	foreach ( $response['data']['vulnerability'] as $v ) {
+
+		// Set vulnerability name if available.
+		$name = null;
+		if ( isset( $v['name'] ) ) {
+			$name = $v['name'];
+		}
+
+		// Set vulnerability link if available.
+		$link = null;
+		if ( isset( $v['link'] ) ) {
+			$link = $v['link'];
+		}
+
 		$vulnerability[] = array(
-			'name'   => wp_kses( (string) $v['name'], 'strip' ),
-			'link'   => esc_url_raw( (string) $v['link'] ),
+			'name'   => wp_kses( (string) $name, 'strip' ),
+			'link'   => esc_url_raw( (string) $link ),
 			'source' => $v['source'],
 			'impact' => $v['impact'],
 		);

--- a/wpvulnerability-general.php
+++ b/wpvulnerability-general.php
@@ -317,7 +317,7 @@ function wpvulnerability_severity( $severity ) {
  *
  * @return array|bool An array with the vulnerability information or false if there's an error.
  */
-function wpvulnerability_get( $type, $slug = '' ) {
+function wpvulnerability_get( $type, $slug = '', $cache = 1 ) {
 
 	$vulnerability_data = null;
 
@@ -352,10 +352,12 @@ function wpvulnerability_get( $type, $slug = '' ) {
 
 	// Cache key.
 	$key = 'wpvulnerability_' . $type . '_' . $slug;
-	if ( is_multisite() ) {
-		$vulnerability_data = get_site_transient( $key );
-	} else {
-		$vulnerability_data = get_transient( $key );
+	if( $cache ) {
+		if ( is_multisite() ) {
+			$vulnerability_data = get_site_transient( $key );
+		} else {
+			$vulnerability_data = get_transient( $key );
+		}
 	}
 
 	// If not cached, get the updated data.
@@ -389,7 +391,7 @@ function wpvulnerability_get( $type, $slug = '' ) {
  *
  * @return array|false Array of vulnerabilities, or false on error.
  */
-function wpvulnerability_get_core( $version = null ) {
+function wpvulnerability_get_core( $version = null, $cache = 1 ) {
 
 	// Sanitize the version number.
 	if ( ! wpvulnerability_sanitize_version( $version ) ) {
@@ -402,7 +404,7 @@ function wpvulnerability_get_core( $version = null ) {
 	}
 
 	// Get vulnerabilities from API.
-	$response = wpvulnerability_get( 'core', $version );
+	$response = wpvulnerability_get( 'core', $version, $cache );
 
 	// Check for errors.
 	if ( ( isset( $response['error'] ) && $response['error'] ) || empty( $response['data']['vulnerability'] ) ) {
@@ -440,7 +442,7 @@ function wpvulnerability_get_core( $version = null ) {
  *
  * @return array|false An array of vulnerabilities or plugin data if `$data` is set to 1, or `false` if no vulnerabilities are found or the version number is invalid and `$data` is not set.
  */
-function wpvulnerability_get_plugin( $slug, $version, $data = 0 ) {
+function wpvulnerability_get_plugin( $slug, $version, $data = 0, $cache = 1 ) {
 
 	// Sanitize the plugin slug.
 	$slug = sanitize_title( $slug );
@@ -451,7 +453,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0 ) {
 	}
 
 	// Get the response from the vulnerability API.
-	$response = wpvulnerability_get( 'plugin', $slug );
+	$response = wpvulnerability_get( 'plugin', $slug, $cache );
 
 	// Create an empty array to store the vulnerabilities.
 	$vulnerability = array();
@@ -549,7 +551,7 @@ function wpvulnerability_get_plugin( $slug, $version, $data = 0 ) {
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
-function wpvulnerability_get_theme( $slug, $version ) {
+function wpvulnerability_get_theme( $slug, $version, $cache = 1 ) {
 
 	// Sanitize the plugin slug.
 	$slug = sanitize_title( $slug );
@@ -560,7 +562,7 @@ function wpvulnerability_get_theme( $slug, $version ) {
 	}
 
 	// Get the response from the vulnerability API.
-	$response = wpvulnerability_get( 'theme', $slug );
+	$response = wpvulnerability_get( 'theme', $slug, $cache );
 
 	// Create an empty array to store the vulnerabilities.
 	$vulnerability = array();
@@ -643,15 +645,18 @@ function wpvulnerability_get_theme( $slug, $version ) {
  *
  * @return array|false Returns an array with the statistical information if successful, false otherwise.
  */
-function wpvulnerability_get_statistics() {
+function wpvulnerability_get_statistics( $cache = 1 ) {
 
+	$vulnerability = null;
 	$key = 'wpvulnerability_stats';
 
 	// Get cached statistics if available.
-	if ( is_multisite() ) {
-		$vulnerability = get_site_transient( $key );
-	} else {
-		$vulnerability = get_transient( $key );
+	if( $cache ) {
+		if ( is_multisite() ) {
+			$vulnerability = get_site_transient( $key );
+		} else {
+			$vulnerability = get_transient( $key );
+		}
 	}
 
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
@@ -712,17 +717,19 @@ function wpvulnerability_get_statistics() {
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
-function wpvulnerability_get_php( $version ) {
+function wpvulnerability_get_php( $version, $cache = 1 ) {
 
-	$key                = 'wpvulnerability_php';
+	$key                  = 'wpvulnerability_php';
 	$vulnerability_data = null;
-	$vulnerability      = array();
+	$vulnerability       = array();
 
 	// Get cached statistics if available.
-	if ( is_multisite() ) {
-		$vulnerability_data = get_site_transient( $key );
-	} else {
-		$vulnerability_data = get_transient( $key );
+	if( $cache ) {
+		if ( is_multisite() ) {
+			$vulnerability_data = get_site_transient( $key );
+		} else {
+			$vulnerability_data = get_transient( $key );
+		}
 	}
 
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
@@ -816,17 +823,19 @@ function wpvulnerability_get_php( $version ) {
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
-function wpvulnerability_get_apache( $version ) {
+function wpvulnerability_get_apache( $version, $cache = 1 ) {
 
 	$key                = 'wpvulnerability_apache';
 	$vulnerability_data = null;
 	$vulnerability      = array();
 
 	// Get cached statistics if available.
-	if ( is_multisite() ) {
-		$vulnerability_data = get_site_transient( $key );
-	} else {
-		$vulnerability_data = get_transient( $key );
+	if( $cache ) {
+		if ( is_multisite() ) {
+			$vulnerability_data = get_site_transient( $key );
+		} else {
+			$vulnerability_data = get_transient( $key );
+		}
 	}
 
 	// If cached statistics are not available, retrieve them from the API and store them in cache.
@@ -920,17 +929,19 @@ function wpvulnerability_get_apache( $version ) {
  *
  * @return array|false Returns an array of vulnerabilities, or false if there are none.
  */
-function wpvulnerability_get_nginx( $version ) {
+function wpvulnerability_get_nginx( $version, $cache = 1 ) {
 
 	$key                = 'wpvulnerability_nginx';
 	$vulnerability_data = null;
 	$vulnerability      = array();
 
 	// Get cached statistics if available.
-	if ( is_multisite() ) {
-		$vulnerability_data = get_site_transient( $key );
-	} else {
-		$vulnerability_data = get_transient( $key );
+	if( $cache ) {
+		if ( is_multisite() ) {
+			$vulnerability_data = get_site_transient( $key );
+		} else {
+			$vulnerability_data = get_transient( $key );
+		}
 	}
 
 	// If cached statistics are not available, retrieve them from the API and store them in cache.

--- a/wpvulnerability-nginx.php
+++ b/wpvulnerability-nginx.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @return array The updated nginx data array.
  */
-function get_fresh_nginx_vulnerabilities() {
+function wpvulnerability_get_fresh_nginx_vulnerabilities() {
 
 	$nginx_version = null;
 	$webserver     = wpvulnerability_detect_webserver();
@@ -32,7 +32,7 @@ function get_fresh_nginx_vulnerabilities() {
 	// Retrieve vulnerabilities for the nginx using its version.
 	if ( $nginx_version ) {
 
-		$nginx_api_response = wpvulnerability_get_nginx( $nginx_version );
+		$nginx_api_response = wpvulnerability_get_nginx( $nginx_version, 0 );
 
 		// If vulnerabilities are found, update the nginx data accordingly.
 		if ( ! empty( $nginx_api_response ) ) {
@@ -58,7 +58,7 @@ function wpvulnerability_nginx_get_installed() {
 
 	$wpvulnerability_nginx_vulnerable = 0;
 
-	$nginx = get_fresh_nginx_vulnerabilities();
+	$nginx = wpvulnerability_get_fresh_nginx_vulnerabilities();
 
 	if ( isset( $nginx['vulnerable'] ) && (int) $nginx['vulnerable'] ) {
 

--- a/wpvulnerability-nginx.php
+++ b/wpvulnerability-nginx.php
@@ -12,9 +12,12 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 /**
  * Retrieves vulnerabilities for an nginx version and updates its data.
  *
+ * This function detects the installed nginx version, checks for vulnerabilities using an external API,
+ * and updates the nginx data array with the vulnerabilities found.
+ *
  * @since 3.2.0
  *
- * @return array The updated nginx data array.
+ * @return array The updated nginx data array containing vulnerability information.
  */
 function wpvulnerability_get_fresh_nginx_vulnerabilities() {
 
@@ -48,88 +51,88 @@ function wpvulnerability_get_fresh_nginx_vulnerabilities() {
 
 /**
  * Get Installed nginx
- * Retrieves the list of installed nginx, checks for vulnerabilities, caches the data, and sends an email notification if vulnerabilities are detected.
+ *
+ * Retrieves the list of installed nginx versions, checks for vulnerabilities,
+ * caches the data, and sends an email notification if vulnerabilities are detected.
  *
  * @since 3.2.0
  *
- * @return string JSON-encoded array of nginx data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of nginx data with vulnerabilities and vulnerable status.
  */
 function wpvulnerability_nginx_get_installed() {
 
 	$wpvulnerability_nginx_vulnerable = 0;
 
+	// Retrieve fresh vulnerabilities for the installed nginx version.
 	$nginx = wpvulnerability_get_fresh_nginx_vulnerabilities();
 
+	// Check if the nginx version is vulnerable and count the vulnerabilities.
 	if ( isset( $nginx['vulnerable'] ) && (int) $nginx['vulnerable'] ) {
-
 		$wpvulnerability_nginx_vulnerable = count( $nginx['vulnerabilities'] );
-
 	}
 
+	// Cache the vulnerability data and the timestamp for cache expiration.
 	if ( is_multisite() ) {
-
 		update_site_option( 'wpvulnerability-nginx', wp_json_encode( $nginx ) );
 		update_site_option( 'wpvulnerability-nginx-vulnerable', wp_json_encode( number_format( $wpvulnerability_nginx_vulnerable, 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
+		update_site_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+	} else {
 		update_option( 'wpvulnerability-nginx', wp_json_encode( $nginx ) );
 		update_option( 'wpvulnerability-nginx-vulnerable', wp_json_encode( number_format( $wpvulnerability_nginx_vulnerable, 0, '.', '' ) ) );
-
+		update_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 	}
 
+	// Return the JSON-encoded array of nginx data.
 	return wp_json_encode( $nginx );
 }
 
 /**
  * Get the cached nginx vulnerabilities or update the cache if it's stale or missing.
  *
+ * This function checks the cache for stored nginx vulnerabilities. If the cache is stale or missing,
+ * it updates the cache with the latest vulnerabilities data.
+ *
  * @since 3.2.0
  *
- * @return array Array of nginx with their vulnerabilities.
+ * @return array Array of nginx data with their vulnerabilities.
  */
 function wpvulnerability_nginx_get_vulnerabilities() {
 
 	if ( is_multisite() ) {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached nginx data and decode it.
 		$nginx_data_cache = json_decode( get_site_option( 'wpvulnerability-nginx-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed nginx data and decode it.
 		$nginx_data = json_decode( get_site_option( 'wpvulnerability-nginx' ), true );
 
-	} elseif ( ! is_multisite() ) {
+	} else {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached nginx data and decode it.
 		$nginx_data_cache = json_decode( get_option( 'wpvulnerability-nginx-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed nginx data and decode it.
 		$nginx_data = json_decode( get_option( 'wpvulnerability-nginx' ), true );
 
 	}
 
-	// If the cache is stale or the plugin data is empty, update the cache.
+	// If the cache is stale or the nginx data is empty, update the cache.
 	if ( $nginx_data_cache < time() || empty( $nginx_data ) ) {
 
-		// Get the installed plugin data and update the cache.
+		// Get the installed nginx data and update the cache.
 		$nginx_data = json_decode( wpvulnerability_nginx_get_installed(), true );
 
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
 	return $nginx_data;
 }
 
 /**
- * Update the nginx cache and remove any old cache data
+ * Update the nginx cache and remove any old cache data.
+ *
+ * This function refreshes the cache for nginx vulnerabilities by calling the function
+ * that retrieves and updates the installed nginx data, ensuring that the cache contains
+ * the most recent information.
  *
  * @since 3.2.0
  *
@@ -137,16 +140,6 @@ function wpvulnerability_nginx_get_vulnerabilities() {
  */
 function wpvulnerability_nginx_get_vulnerabilities_clean() {
 
-	// Update the installed plugins cache.
+	// Update the installed nginx cache.
 	wpvulnerability_nginx_get_installed();
-
-	if ( is_multisite() ) {
-
-		update_site_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
-		update_option( 'wpvulnerability-nginx-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	}
 }

--- a/wpvulnerability-notifications.php
+++ b/wpvulnerability-notifications.php
@@ -10,13 +10,17 @@
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
 /**
- * Adds a custom schedule for weekly cron job.
+ * Adds a custom schedule for a weekly cron job.
+ *
+ * This function adds a new schedule interval of one week (604800 seconds)
+ * to the system's available cron schedules. It allows tasks to be scheduled
+ * to run every week using the 'weekly' interval.
  *
  * @since 2.0.0
  *
- * @param array $schedules The system schedules.
+ * @param array $schedules The existing system schedules.
  *
- * @return array The updated list of schedules.
+ * @return array The updated list of schedules with the added weekly interval.
  */
 function wpvulnerability_add_every_week( $schedules ) {
 
@@ -30,17 +34,21 @@ function wpvulnerability_add_every_week( $schedules ) {
 	return $schedules;
 }
 
-// Hook into the 'cron_schedules' filter to add custom schedule.
+// Hook the function to the 'cron_schedules' filter to add the custom schedule.
 add_filter( 'cron_schedules', 'wpvulnerability_add_every_week' );
 
 /**
- * Add a custom schedule for daily events.
+ * Adds a custom schedule for daily events.
+ *
+ * This function adds a new schedule interval of one day (86400 seconds)
+ * to the system's available cron schedules. It allows tasks to be scheduled
+ * to run every day using the 'daily' interval.
  *
  * @since 2.0.0
  *
  * @param array $schedules List of available schedules.
  *
- * @return array Modified list of available schedules.
+ * @return array Modified list of available schedules with the added daily interval.
  */
 function wpvulnerability_add_every_day( $schedules ) {
 
@@ -53,15 +61,19 @@ function wpvulnerability_add_every_day( $schedules ) {
 	// Return the modified list of schedules.
 	return $schedules;
 }
-// Hook the function to the 'cron_schedules' filter.
+
+// Hook the function to the 'cron_schedules' filter to add the custom schedule.
 add_filter( 'cron_schedules', 'wpvulnerability_add_every_day' );
 
 /**
  * Prepares the HTML email message
  *
+ * This function generates an HTML email message with the given title and content.
+ * It includes basic styling and structure to ensure compatibility with most email clients.
+ *
  * @since 2.0.0
  *
- * @param string $title The title of the email message.
+ * @param string $title   The title of the email message.
  * @param string $content The content of the email message.
  *
  * @return string The prepared HTML email message.
@@ -107,21 +119,18 @@ function wpvulnerability_email_prepare( $title, $content ) {
 	$message .= '											<img class="aligncenter" src="' . WPVULNERABILITY_PLUGIN_URL . 'assets/logo64.png" width="64" height="64" alt="WPVulnerability">' . "\n";
 	$message .= '											<h1 class="aligncenter" style="box-sizing: border-box; color: #000; line-height: 1.2em; text-align: center; margin: 40px 0 0;" align="center">' . $title . '</h1>' . "\n";
 
+	// Add the site URL based on the multisite configuration.
 	if ( is_multisite() ) {
-
 		$message .= '											<p class="aligncenter" style="box-sizing: border-box; color: #000; line-height: 1.2em; text-align: center; margin: 5px 0 0;" align="center"><a href="' . network_site_url() . '" target="_blank" rel="noopener noreferrer">' . network_site_url() . '</a></p>' . "\n";
-
-	} elseif ( ! is_multisite() ) {
-
+	} else {
 		$message .= '											<p class="aligncenter" style="box-sizing: border-box; color: #000; line-height: 1.2em; text-align: center; margin: 5px 0 0;" align="center"><a href="' . site_url() . '" target="_blank" rel="noopener noreferrer">' . site_url() . '</a></p>' . "\n";
-
 	}
 
 	$message .= '										</td>' . "\n";
 	$message .= '									</tr>' . "\n";
 	$message .= '									<tr style="box-sizing: border-box; margin: 0;">' . "\n";
-	$message .= '										<td class="content-block alignlef" style="box-sizing: border-box; vertical-align: top; text-align: left; margin: 0; padding: 0 0 20px;" valign="top">' . "\n";
-	$message .= $content;
+	$message .= '										<td class="content-block alignleft" style="box-sizing: border-box; vertical-align: top; text-align: left; margin: 0; padding: 0 0 20px;" valign="top">' . "\n";
+	$message .= $content; // Add the main content of the email.
 	$message .= '									</td>' . "\n";
 	$message .= '									</tr>' . "\n";
 	$message .= '								</table>' . "\n";
@@ -137,16 +146,12 @@ function wpvulnerability_email_prepare( $title, $content ) {
 	);
 	$message .= '											</td>' . "\n";
 	$message .= '										</tr>' . "\n";
-	$message .= '										<tr style="box-sizing: border-box; margin: 0;">' . "\n";
 
+	// Add the site URL in the footer based on the multisite configuration.
 	if ( is_multisite() ) {
-
 		$message .= '											<td class="aligncenter content-block" style="box-sizing: border-box; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top"><a href="' . network_site_url() . '" target="_blank" rel="noopener noreferrer">' . network_site_url() . '</a></td>' . "\n";
-
-	} elseif ( ! is_multisite() ) {
-
+	} else {
 		$message .= '											<td class="aligncenter content-block" style="box-sizing: border-box; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top"><a href="' . site_url() . '" target="_blank" rel="noopener noreferrer">' . site_url() . '</a></td>' . "\n";
-
 	}
 
 	$message .= '										</tr>' . "\n";
@@ -188,7 +193,7 @@ function wpvulnerability_execute_notification( $forced = false ) {
 		$wpvulnerability_settings = get_option( 'wpvulnerability-config' );
 	}
 
-	// required by the "forced email" button.
+	// Required by the "forced email" button.
 	if ( ! $forced ) {
 
 		// If email or period settings are empty, return.
@@ -243,7 +248,7 @@ function wpvulnerability_execute_notification( $forced = false ) {
 		$html_nginx = wpvulnerability_html_nginx();
 	}
 
-	// required by the "forced email" button.
+	// Required by the "forced email" button.
 	if ( ! $forced ) {
 
 		// If no vulnerabilities were found, return.
@@ -255,7 +260,7 @@ function wpvulnerability_execute_notification( $forced = false ) {
 		// If no vulnerabilities were found, return.
 		if ( empty( $html_core ) && empty( $html_plugins ) && empty( $html_themes ) && empty( $html_php ) && empty( $html_apache ) && empty( $html_nginx ) ) {
 			$email_content .= '<h2>' . esc_html__( 'There are no vulnerabilities', 'wpvulnerability' ) . '</h2>';
-			$email_content .= '<p>' . esc_html__( 'This is probably a test. The site probably does not have vulnerabilities.', 'wpvulnerability' );
+			$email_content .= '<p>' . esc_html__( 'This is probably a test. The site probably does not have vulnerabilities.', 'wpvulnerability' ) . '</p>';
 		}
 	}
 
@@ -295,21 +300,22 @@ function wpvulnerability_execute_notification( $forced = false ) {
 		$email_content .= $html_nginx;
 	}
 
-	// Site name.
+	// Get the site name.
 	if ( is_multisite() ) {
 		$admin_site = get_site_option( 'network_name_option' );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$admin_site = get_bloginfo( 'name' );
 	}
 
-	// Admin email.
+	// Get the admin email.
 	if ( is_multisite() ) {
 		$admin_email = get_site_option( 'admin_email' );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$admin_email = get_bloginfo( 'admin_email' );
 	}
 	$from_email = $admin_email;
 
+	// Check if WPVULNERABILITY_MAIL is defined and valid.
 	if ( defined( 'WPVULNERABILITY_MAIL' ) ) {
 		$wpvulnerability_sender_email = sanitize_email( trim( WPVULNERABILITY_MAIL ) );
 		if ( is_email( $wpvulnerability_sender_email ) ) {
@@ -320,7 +326,7 @@ function wpvulnerability_execute_notification( $forced = false ) {
 
 	// Prepare email subject and content.
 	$email_subject = sprintf(
-	// translators: Site name.
+		// translators: Site name.
 		__( 'Vulnerability found: %s', 'wpvulnerability' ),
 		$admin_site
 	);

--- a/wpvulnerability-php.php
+++ b/wpvulnerability-php.php
@@ -10,70 +10,76 @@
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
 /**
- * Retrieves vulnerabilities for a PHP version and updates its data.
+ * Retrieves vulnerabilities for the current PHP version and updates its data.
+ *
+ * This function sanitizes and retrieves the current PHP version, checks for vulnerabilities
+ * using an external API, and updates the PHP data array with the vulnerabilities found.
  *
  * @since 3.0.0
  *
- * @return array The updated PHP data array.
+ * @return array The updated PHP data array containing vulnerability information.
  */
 function wpvulnerability_get_fresh_php_vulnerabilities() {
 
-	// Get the PHP version.
+	// Get the PHP version and sanitize it.
 	$php_version = wp_kses( wpvulnerability_sanitize_version_php( phpversion() ), 'strip' );
 
-	// Initialize vulnerability related fields.
-	$php_data['vulnerabilities'] = null;
-	$php_data['vulnerable']      = 0;
+	// Initialize PHP data with default values.
+	$php_data = array(
+		'vulnerabilities' => null,
+		'vulnerable'      => 0,
+	);
 
-	// Retrieve vulnerabilities for the PHP using its version.
+	// Retrieve vulnerabilities for the PHP version.
 	if ( $php_version ) {
-
+		// Call the API to get vulnerabilities for the sanitized PHP version.
 		$php_api_response = wpvulnerability_get_php( $php_version, 0 );
 
 		// If vulnerabilities are found, update the PHP data accordingly.
 		if ( ! empty( $php_api_response ) ) {
-
 			$php_data['vulnerabilities'] = $php_api_response;
 			$php_data['vulnerable']      = 1;
-
 		}
 	}
 
+	// Return the updated PHP data array.
 	return $php_data;
 }
 
 /**
  * Get Installed PHP
- * Retrieves the list of installed PHP, checks for vulnerabilities, caches the data, and sends an email notification if vulnerabilities are detected.
+ *
+ * Retrieves the list of installed PHP versions, checks for vulnerabilities,
+ * caches the data, and sends an email notification if vulnerabilities are detected.
  *
  * @since 3.0.0
  *
- * @return string JSON-encoded array of PHP data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of PHP data with vulnerabilities and vulnerable status.
  */
 function wpvulnerability_php_get_installed() {
 
 	$wpvulnerability_php_vulnerable = 0;
 
+	// Retrieve fresh vulnerabilities for the installed PHP version.
 	$php = wpvulnerability_get_fresh_php_vulnerabilities();
 
+	// Check if the PHP version is vulnerable and count the vulnerabilities.
 	if ( isset( $php['vulnerable'] ) && (int) $php['vulnerable'] ) {
-
 		$wpvulnerability_php_vulnerable = count( $php['vulnerabilities'] );
-
 	}
 
+	// Cache the vulnerability data and the timestamp for cache expiration.
 	if ( is_multisite() ) {
-
 		update_site_option( 'wpvulnerability-php', wp_json_encode( $php ) );
 		update_site_option( 'wpvulnerability-php-vulnerable', wp_json_encode( number_format( $wpvulnerability_php_vulnerable, 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
+		update_site_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+	} else {
 		update_option( 'wpvulnerability-php', wp_json_encode( $php ) );
 		update_option( 'wpvulnerability-php-vulnerable', wp_json_encode( number_format( $wpvulnerability_php_vulnerable, 0, '.', '' ) ) );
-
+		update_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 	}
 
+	// Return the JSON-encoded array of PHP data.
 	return wp_json_encode( $php );
 }
 
@@ -88,44 +94,35 @@ function wpvulnerability_php_get_vulnerabilities() {
 
 	if ( is_multisite() ) {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached PHP data and decode it.
 		$php_data_cache = json_decode( get_site_option( 'wpvulnerability-php-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed PHP data and decode it.
 		$php_data = json_decode( get_site_option( 'wpvulnerability-php' ), true );
 
-	} elseif ( ! is_multisite() ) {
+	} else {
 
-		// Get the cached plugin data and decode it.
+		// Get the cached PHP data and decode it.
 		$php_data_cache = json_decode( get_option( 'wpvulnerability-php-cache' ) );
 
-		// Get the installed plugin data and decode it.
+		// Get the installed PHP data and decode it.
 		$php_data = json_decode( get_option( 'wpvulnerability-php' ), true );
 
 	}
 
-	// If the cache is stale or the plugin data is empty, update the cache.
+	// If the cache is stale or the PHP data is empty, update the cache.
 	if ( $php_data_cache < time() || empty( $php_data ) ) {
 
-		// Get the installed plugin data and update the cache.
+		// Get the installed PHP data and update the cache.
 		$php_data = json_decode( wpvulnerability_php_get_installed(), true );
 
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
 	return $php_data;
 }
 
 /**
- * Update the PHP cache and remove any old cache data
+ * Update the PHP cache and remove any old cache data.
  *
  * @since 3.0.0
  *
@@ -133,16 +130,6 @@ function wpvulnerability_php_get_vulnerabilities() {
  */
 function wpvulnerability_php_get_vulnerabilities_clean() {
 
-	// Update the installed plugins cache.
+	// Update the installed PHP cache.
 	wpvulnerability_php_get_installed();
-
-	if ( is_multisite() ) {
-
-		update_site_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
-		update_option( 'wpvulnerability-php-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	}
 }

--- a/wpvulnerability-php.php
+++ b/wpvulnerability-php.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @return array The updated PHP data array.
  */
-function get_fresh_php_vulnerabilities() {
+function wpvulnerability_get_fresh_php_vulnerabilities() {
 
 	// Get the PHP version.
 	$php_version = wp_kses( wpvulnerability_sanitize_version_php( phpversion() ), 'strip' );
@@ -28,7 +28,7 @@ function get_fresh_php_vulnerabilities() {
 	// Retrieve vulnerabilities for the PHP using its version.
 	if ( $php_version ) {
 
-		$php_api_response = wpvulnerability_get_php( $php_version );
+		$php_api_response = wpvulnerability_get_php( $php_version, 0 );
 
 		// If vulnerabilities are found, update the PHP data accordingly.
 		if ( ! empty( $php_api_response ) ) {
@@ -54,7 +54,7 @@ function wpvulnerability_php_get_installed() {
 
 	$wpvulnerability_php_vulnerable = 0;
 
-	$php = get_fresh_php_vulnerabilities();
+	$php = wpvulnerability_get_fresh_php_vulnerabilities();
 
 	if ( isset( $php['vulnerable'] ) && (int) $php['vulnerable'] ) {
 

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -165,6 +165,7 @@ function get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
 		// If vulnerabilities are found, update the plugin data accordingly.
 		if ( ! empty( $plugin_api_response ) ) {
 
+			$plugin_data['slug'] = $plugin_slug;
 			$plugin_data['vulnerabilities'] = $plugin_api_response;
 			$plugin_data['vulnerable']      = 1;
 

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -165,7 +165,7 @@ function get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
 		// If vulnerabilities are found, update the plugin data accordingly.
 		if ( ! empty( $plugin_api_response ) ) {
 
-			$plugin_data['slug'] = $plugin_slug;
+			$plugin_data['slug']            = $plugin_slug;
 			$plugin_data['vulnerabilities'] = $plugin_api_response;
 			$plugin_data['vulnerable']      = 1;
 

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -547,13 +547,7 @@ function wpvulnerability_plugin_page() {
 	// Check if the current page is the plugins page.
 	global $pagenow;
 
-	if (
-		wpvulnerability_analyze_filter( 'plugins' ) && 'plugins.php' === $pagenow &&
-		(
-			( is_multisite() && is_network_admin() && current_user_can( 'manage_network' ) ) ||
-			( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) )
-		)
-	) {
+	if ( wpvulnerability_analyze_filter( 'plugins' ) && 'plugins.php' === $pagenow && wpvulnerability_capabilities() ) {
 
 		// Get the vulnerabilities for the installed plugins.
 		$plugins = wpvulnerability_plugin_get_vulnerabilities();
@@ -568,11 +562,11 @@ function wpvulnerability_plugin_page() {
 			}
 		}
 
-		if ( is_multisite() && is_network_admin() && current_user_can( 'manage_network' ) ) {
+		if ( wpvulnerability_capabilities() ) {
 
 			add_filter( 'manage_plugins-network_columns', 'wpvulnerability_plugin_add_lastupdated_column' );
 
-		} elseif ( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) ) {
+		} elseif ( wpvulnerability_capabilities() ) {
 
 			add_filter( 'manage_plugins_columns', 'wpvulnerability_plugin_add_lastupdated_column' );
 

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @since 2.0.0
  *
- * @param  string $plugin_file Main plugin folder/file name.
- * @param  array  $plugin_data Plugin data.
+ * @param string $plugin_file Main plugin folder/file name.
+ * @param array  $plugin_data Plugin data.
  *
  * @return void
  */
@@ -136,24 +136,24 @@ function wpvulnerability_get_fresh_plugin_vulnerabilities( $plugin_data, $file_p
 
 	$plugin_slug = null;
 
-	// Extract it from the file path.
+	// Extract the folder name from the file path.
 	$folder_name = explode( '/', $file_path );
 
-	// If not, use the TextDomain key.
+	// If a folder name is found, use it as the plugin slug.
 	if ( isset( $folder_name[0] ) ) {
 		$plugin_slug = wp_kses( trim( (string) $folder_name[0] ), 'strip' );
 	}
 	unset( $folder_name );
 
-	// If the TextDomain key is empty, extract it from the file path.
+	// If the plugin slug is still null, use the TextDomain key from the plugin data.
 	if ( is_null( $plugin_slug ) ) {
 		$plugin_slug = wp_kses( (string) $plugin_data['TextDomain'], 'strip' );
 	}
 
-	// Get the plugin slug and version from the plugin data.
+	// Get the plugin version from the plugin data.
 	$plugin_version = wp_kses( (string) $plugin_data['Version'], 'strip' );
 
-	// Initialize vulnerability related fields.
+	// Initialize vulnerability-related fields.
 	$plugin_data['vulnerabilities'] = null;
 	$plugin_data['vulnerable']      = 0;
 
@@ -189,27 +189,27 @@ function wpvulnerability_get_fresh_plugin_data( $plugin_data, $file_path ) {
 
 	$plugin_slug = null;
 
-	// Extract it from the file path.
+	// Extract the folder name from the file path.
 	$folder_name = explode( '/', $file_path );
 
-	// If not, use the TextDomain key.
+	// If a folder name is found, use it as the plugin slug.
 	if ( isset( $folder_name[0] ) ) {
 		$plugin_slug = wp_kses( trim( (string) $folder_name[0] ), 'strip' );
 	}
 	unset( $folder_name );
 
-	// If the TextDomain key is empty, extract it from the file path.
+	// If the plugin slug is still null, use the TextDomain key from the plugin data.
 	if ( is_null( $plugin_slug ) ) {
 		$plugin_slug = wp_kses( (string) $plugin_data['TextDomain'], 'strip' );
 	}
 
-	// Get the plugin slug and version from the plugin data.
+	// Get the plugin version from the plugin data.
 	$plugin_version = wp_kses( (string) $plugin_data['Version'], 'strip' );
 
 	// Retrieve vulnerabilities for the plugin using its slug and version.
 	if ( $plugin_slug ) {
 
-		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, 0, 1, 0 );
+		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, $plugin_version, 0, 1 );
 
 		// If vulnerabilities are found, update the plugin data accordingly.
 		if ( ! empty( $plugin_api_response ) ) {
@@ -228,38 +228,44 @@ function wpvulnerability_get_fresh_plugin_data( $plugin_data, $file_path ) {
  *
  * @since 2.0.0
  *
- * @return string JSON-encoded array of plugin data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of plugin data with vulnerabilities and vulnerable status.
  */
 function wpvulnerability_plugin_get_installed() {
 
 	$wpvulnerability_plugins_vulnerable = 0;
 
+	// Ensure the get_plugins() function is available.
 	if ( ! function_exists( 'get_plugins' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
 
+	// Retrieve the list of installed plugins.
 	$plugins = get_plugins();
 
+	// Iterate through each plugin and check for vulnerabilities.
 	foreach ( $plugins as $file_path => $plugin_data ) {
 
 		$plugins[ $file_path ] = wpvulnerability_get_fresh_plugin_vulnerabilities( $plugin_data, $file_path );
 
+		// Increment the vulnerable plugin counter if vulnerabilities are found.
 		if ( isset( $plugins[ $file_path ]['vulnerable'] ) && (int) $plugins[ $file_path ]['vulnerable'] ) {
-
 			++$wpvulnerability_plugins_vulnerable;
-
 		}
 	}
 
+	// Update site options for multisite installations.
 	if ( is_multisite() ) {
 
 		update_site_option( 'wpvulnerability-plugins', wp_json_encode( $plugins ) );
 		update_site_option( 'wpvulnerability-plugins-vulnerable', wp_json_encode( number_format( $wpvulnerability_plugins_vulnerable, 0, '.', '' ) ) );
+		update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
+	// Update options for single site installations.
 	} elseif ( ! is_multisite() ) {
 
 		update_option( 'wpvulnerability-plugins', wp_json_encode( $plugins ) );
 		update_option( 'wpvulnerability-plugins-vulnerable', wp_json_encode( number_format( $wpvulnerability_plugins_vulnerable, 0, '.', '' ) ) );
+		update_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
 	}
 
@@ -295,31 +301,37 @@ function wpvulnerability_plugin_get_data( $clean = false ) {
 
 	}
 
+	// Refresh the cache if it is stale, empty, or forced refresh is requested.
 	if ( $plugin_data_cache < time() || empty( $plugin_data ) || $clean ) {
 
+		// Ensure the get_plugins() function is available.
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		// Retrieve the list of installed plugins.
 		$plugins = get_plugins();
 
 		$pluginsdata = array();
 
+		// Iterate through each plugin and get fresh data.
 		foreach ( $plugins as $file_path => $plugin_data ) {
-
 			$pluginsdata[ $file_path ] = wpvulnerability_get_fresh_plugin_data( $plugin_data, $file_path );
-
 		}
 
+		// Update site options for multisite installations.
 		if ( is_multisite() ) {
 
 			update_site_option( 'wpvulnerability-plugins-data', wp_json_encode( $pluginsdata ) );
 			update_site_option( 'wpvulnerability-plugins-cache-data', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+			update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
+		// Update options for single site installations.
 		} elseif ( ! is_multisite() ) {
 
 			update_option( 'wpvulnerability-plugins-data', wp_json_encode( $pluginsdata ) );
 			update_option( 'wpvulnerability-plugins-cache-data', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
+			update_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
 		}
 	}
@@ -344,7 +356,7 @@ function wpvulnerability_plugin_get_vulnerabilities() {
 		// Get the installed plugin data and decode it.
 		$plugin_data = json_decode( get_site_option( 'wpvulnerability-plugins' ), true );
 
-	} elseif ( ! is_multisite() ) {
+	} else {
 
 		// Get the cached plugin data and decode it.
 		$plugin_data_cache = json_decode( get_option( 'wpvulnerability-plugins-cache' ) );
@@ -360,15 +372,6 @@ function wpvulnerability_plugin_get_vulnerabilities() {
 		// Get the installed plugin data and update the cache.
 		$plugin_data = json_decode( wpvulnerability_plugin_get_installed(), true );
 
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
 	return $plugin_data;
@@ -385,16 +388,6 @@ function wpvulnerability_plugin_get_vulnerabilities_clean() {
 
 	// Update the installed plugins cache.
 	wpvulnerability_plugin_get_installed();
-
-	if ( is_multisite() ) {
-
-		update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
-		update_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	}
 
 	// Update the plugins data cache.
 	wpvulnerability_plugin_get_data( true );
@@ -422,7 +415,7 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 
 		$plugin_slug = null;
 
-		// Extract it from the file path.
+		// Extract the plugin slug from the file path.
 		$folder_name = explode( '/', $plugin_file );
 
 		// If not, use the TextDomain key.
@@ -441,56 +434,39 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 			// Retrieve the vulnerabilities for all plugins from the options table and decode the JSON.
 			if ( is_multisite() ) {
 				$plugins_data = json_decode( get_site_option( 'wpvulnerability-plugins-data' ), true );
-			} elseif ( ! is_multisite() ) {
+			} else {
 				$plugins_data = json_decode( get_option( 'wpvulnerability-plugins-data' ), true );
 			}
 
-			// Loop through all vulnerabilities for the current plugin and add their details to the table row HTML markup.
-			$plugin_data = $plugins_data[ $plugin_file ];
+			// Get the plugin data from the stored data.
+			if ( isset( $plugins_data[ $plugin_file ] ) ) {
+				$plugin_data = $plugins_data[ $plugin_file ];
 
-			if ( isset( $plugin_data['latest'] ) && (int) $plugin_data['latest'] > 0 ) {
+				if ( isset( $plugin_data['latest'] ) && (int) $plugin_data['latest'] > 0 ) {
 
-				$plugin_data_updated = wp_date( get_option( 'date_format' ), (int) $plugin_data['latest'] );
+					$plugin_data_updated = wp_date( get_option( 'date_format' ), (int) $plugin_data['latest'] );
 
-				$plugin_data_ago = human_time_diff( (int) $plugin_data['latest'] );
+					$plugin_data_ago = human_time_diff( (int) $plugin_data['latest'] );
 
-				$warning_date = false;
+					$warning_date = (int) $plugin_data['latest'] < $year;
+					$warning_closed = isset( $plugin_data['closed'] ) && (int) $plugin_data['closed'];
 
-				if ( (int) $plugin_data['latest'] < $year ) {
+					echo '<p>' . wp_kses( (string) $plugin_data_updated, 'strip' ) . ' (' . wp_kses( (string) $plugin_data_ago, 'strip' ) . ')</p>';
 
-					$warning_date = true;
+					if ( $warning_date ) {
+						echo '<p><strong>⚠️ ';
+						esc_html_e( 'It hasn\'t been updated in over a year.', 'wpvulnerability' );
+						echo '</strong></p>';
+					}
 
+					if ( $warning_closed ) {
+						echo '<p><strong>⚠️ ';
+						esc_html_e( 'It may no longer be available (closed?).', 'wpvulnerability' );
+						echo '</strong></p>';
+					}
+				} else {
+					echo '<p></p>';
 				}
-
-				$warning_closed = false;
-
-				if ( isset( $plugin_data['closed'] ) && (int) $plugin_data['closed'] ) {
-
-					$warning_closed = true;
-
-				}
-
-				echo '<p>' . wp_kses( (string) $plugin_data_updated, 'strip' ) . ' (' . wp_kses( (string) $plugin_data_ago, 'strip' ) . ')</p>';
-
-				if ( $warning_date ) {
-
-					echo '<p><strong>⚠️ ';
-					esc_html_e( 'It hasn\'t been updated in over a year.', 'wpvulnerability' );
-					echo '</strong></p>';
-
-				}
-
-				if ( $warning_closed ) {
-
-					echo '<p><strong>⚠️ ';
-					esc_html_e( 'It may no longer be available (closed?).', 'wpvulnerability' );
-					echo '</strong></p>';
-
-				}
-			} else {
-
-				echo '<p></p>';
-
 			}
 		}
 	}
@@ -499,7 +475,9 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 /**
  * Adds a 'Last Updated' column to the plugins table list in the WordPress admin area.
  *
- * This function iterates over the existing columns in the plugins table and inserts a new column titled 'Last Updated' just before the 'auto-updates' column if it exists. If the 'auto-updates' column is not found, the 'Last Updated' column is appended at the end. The function is typically hooked to the 'manage_plugins_columns' filter in WordPress to modify the columns of the plugins table.
+ * This function iterates over the existing columns in the plugins table and inserts a new column titled 'Last Updated' just before the 'auto-updates' column if it exists.
+ * If the 'auto-updates' column is not found, the 'Last Updated' column is appended at the end.
+ * The function is typically hooked to the 'manage_plugins_columns' filter in WordPress to modify the columns of the plugins table.
  *
  * @since 3.1.0 Introduced.
  *
@@ -525,9 +503,9 @@ function wpvulnerability_plugin_add_lastupdated_column( $columns ) {
 		$new_columns[ $key ] = $title;
 	}
 
-	if ( ! $toadd ) {
+	// If 'auto-updates' column is not found, add 'last_updated' column at the end.
+	if ( $toadd ) {
 		$new_columns['last_updated'] = __( 'Last updated on', 'wpvulnerability' );
-		$toadd                       = true;
 	}
 
 	// Return the modified columns array.
@@ -536,7 +514,7 @@ function wpvulnerability_plugin_add_lastupdated_column( $columns ) {
 
 /**
  * Admin Head
- * Adds vulnerability information after the plugin row and notices on the plugin page based on the installed plugins cache
+ * Adds vulnerability information after the plugin row and notices on the plugin page based on the installed plugins cache.
  *
  * @since 2.0.0
  *
@@ -562,11 +540,12 @@ function wpvulnerability_plugin_page() {
 			}
 		}
 
-		if ( wpvulnerability_capabilities() ) {
+		// Add 'Last Updated' column to the plugins table based on user capabilities.
+		if ( is_multisite() ) {
 
 			add_filter( 'manage_plugins-network_columns', 'wpvulnerability_plugin_add_lastupdated_column' );
 
-		} elseif ( wpvulnerability_capabilities() ) {
+		} else {
 
 			add_filter( 'manage_plugins_columns', 'wpvulnerability_plugin_add_lastupdated_column' );
 

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -260,7 +260,7 @@ function wpvulnerability_plugin_get_installed() {
 		update_site_option( 'wpvulnerability-plugins-vulnerable', wp_json_encode( number_format( $wpvulnerability_plugins_vulnerable, 0, '.', '' ) ) );
 		update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
-	// Update options for single site installations.
+		// Update options for single site installations.
 	} elseif ( ! is_multisite() ) {
 
 		update_option( 'wpvulnerability-plugins', wp_json_encode( $plugins ) );
@@ -326,7 +326,7 @@ function wpvulnerability_plugin_get_data( $clean = false ) {
 			update_site_option( 'wpvulnerability-plugins-cache-data', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 			update_site_option( 'wpvulnerability-plugins-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
-		// Update options for single site installations.
+			// Update options for single site installations.
 		} elseif ( ! is_multisite() ) {
 
 			update_option( 'wpvulnerability-plugins-data', wp_json_encode( $pluginsdata ) );
@@ -448,7 +448,7 @@ function wpvulnerability_plugin_show_lastupdated( $column_name, $plugin_file, $p
 
 					$plugin_data_ago = human_time_diff( (int) $plugin_data['latest'] );
 
-					$warning_date = (int) $plugin_data['latest'] < $year;
+					$warning_date   = (int) $plugin_data['latest'] < $year;
 					$warning_closed = isset( $plugin_data['closed'] ) && (int) $plugin_data['closed'];
 
 					echo '<p>' . wp_kses( (string) $plugin_data_updated, 'strip' ) . ' (' . wp_kses( (string) $plugin_data_ago, 'strip' ) . ')</p>';

--- a/wpvulnerability-plugins.php
+++ b/wpvulnerability-plugins.php
@@ -132,7 +132,7 @@ function wpvulnerability_plugin_info_after( $plugin_file, $plugin_data ) {
  *
  * @return array The updated plugin data array.
  */
-function get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
+function wpvulnerability_get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
 
 	$plugin_slug = null;
 
@@ -160,7 +160,7 @@ function get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
 	// Retrieve vulnerabilities for the plugin using its slug and version.
 	if ( $plugin_slug ) {
 
-		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, $plugin_version );
+		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, $plugin_version, 0, 0 );
 
 		// If vulnerabilities are found, update the plugin data accordingly.
 		if ( ! empty( $plugin_api_response ) ) {
@@ -185,7 +185,7 @@ function get_fresh_plugin_vulnerabilities( $plugin_data, $file_path ) {
  *
  * @return array|null Updated plugin data array with fresh information or null if the plugin slug cannot be determined or no updated information is available.
  */
-function get_fresh_plugin_data( $plugin_data, $file_path ) {
+function wpvulnerability_get_fresh_plugin_data( $plugin_data, $file_path ) {
 
 	$plugin_slug = null;
 
@@ -209,7 +209,7 @@ function get_fresh_plugin_data( $plugin_data, $file_path ) {
 	// Retrieve vulnerabilities for the plugin using its slug and version.
 	if ( $plugin_slug ) {
 
-		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, 0, 1 );
+		$plugin_api_response = wpvulnerability_get_plugin( $plugin_slug, 0, 1, 0 );
 
 		// If vulnerabilities are found, update the plugin data accordingly.
 		if ( ! empty( $plugin_api_response ) ) {
@@ -242,7 +242,7 @@ function wpvulnerability_plugin_get_installed() {
 
 	foreach ( $plugins as $file_path => $plugin_data ) {
 
-		$plugins[ $file_path ] = get_fresh_plugin_vulnerabilities( $plugin_data, $file_path );
+		$plugins[ $file_path ] = wpvulnerability_get_fresh_plugin_vulnerabilities( $plugin_data, $file_path );
 
 		if ( isset( $plugins[ $file_path ]['vulnerable'] ) && (int) $plugins[ $file_path ]['vulnerable'] ) {
 
@@ -307,7 +307,7 @@ function wpvulnerability_plugin_get_data( $clean = false ) {
 
 		foreach ( $plugins as $file_path => $plugin_data ) {
 
-			$pluginsdata[ $file_path ] = get_fresh_plugin_data( $plugin_data, $file_path );
+			$pluginsdata[ $file_path ] = wpvulnerability_get_fresh_plugin_data( $plugin_data, $file_path );
 
 		}
 

--- a/wpvulnerability-process.php
+++ b/wpvulnerability-process.php
@@ -14,10 +14,10 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @version 2.0.0
  *
- * @param string $type Type: core, plugin, theme.
+ * @param string $type Type: core, plugin, theme, php, apache, nginx.
  * @param array  $vulnerabilities Vulnerability data.
  *
- * @return string
+ * @return string The HTML representation of vulnerabilities.
  */
 function wpvulnerability_html( $type, $vulnerabilities ) {
 
@@ -194,6 +194,7 @@ function wpvulnerability_html_plugins() {
 
 	foreach ( $plugins as $file_path => $plugin_data ) {
 
+		// Check if the plugin is marked as vulnerable.
 		if ( isset( $plugin_data['vulnerable'] ) && 1 === $plugin_data['vulnerable'] ) {
 
 			$found = true;
@@ -205,11 +206,11 @@ function wpvulnerability_html_plugins() {
 		}
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -226,23 +227,25 @@ function wpvulnerability_html_php() {
 	$html  = '';
 	$found = false;
 
+	// Get the PHP vulnerabilities data.
 	$php = wpvulnerability_php_get_vulnerabilities();
 
+	// Check if PHP is marked as vulnerable.
 	if ( isset( $php['vulnerable'] ) && 1 === $php['vulnerable'] ) {
 
 		$found = true;
 
-		// Generate HTML markup for the plugin vulnerability.
+		// Generate HTML markup for the PHP vulnerability.
 		$html .= '<h3>' . esc_html__( 'PHP running', 'wpvulnerability' ) . ': ' . wp_kses( wpvulnerability_sanitize_version_php( phpversion() ), 'strip' ) . '</h3>';
 		$html .= wpvulnerability_html( 'php', $php['vulnerabilities'] );
 
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -259,36 +262,37 @@ function wpvulnerability_html_apache() {
 	$html  = '';
 	$found = false;
 
+	// Check if the function to get Apache vulnerabilities is available, if not include the necessary file.
 	if ( ! function_exists( 'wpvulnerability_apache_get_vulnerabilities' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-apache.php';
 	}
 
+	// Get Apache vulnerabilities data.
 	$apache = wpvulnerability_apache_get_vulnerabilities();
 
+	// Check if Apache is marked as vulnerable.
 	if ( isset( $apache['vulnerable'] ) && 1 === $apache['vulnerable'] ) {
 
 		$found = true;
 
-		// Generate HTML markup for the plugin vulnerability.
+		// Generate HTML markup for the Apache vulnerability.
 		$webserver = wpvulnerability_detect_webserver();
 		if ( isset( $webserver['id'] ) && 'apache' === $webserver['id'] && isset( $webserver['version'] ) && $webserver['version'] ) {
 			// Get the Apache HTTPD version.
 			$apache_version = wp_kses( (string) $webserver['version'], 'strip' );
 
 			if ( $apache_version ) {
-
 				$html .= '<h3>' . esc_html__( 'Apache running', 'wpvulnerability' ) . ': ' . wp_kses( wpvulnerability_sanitize_version_apache( (string) $apache_version ), 'strip' ) . '</h3>';
 				$html .= wpvulnerability_html( 'apache', $apache['vulnerabilities'] );
-
 			}
 		}
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -305,36 +309,37 @@ function wpvulnerability_html_nginx() {
 	$html  = '';
 	$found = false;
 
+	// Check if the function to get nginx vulnerabilities is available, if not include the necessary file.
 	if ( ! function_exists( 'wpvulnerability_nginx_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-nginx.php';
 	}
 
+	// Get nginx vulnerabilities data.
 	$nginx = wpvulnerability_nginx_get_vulnerabilities();
 
+	// Check if nginx is marked as vulnerable.
 	if ( isset( $nginx['vulnerable'] ) && 1 === $nginx['vulnerable'] ) {
 
 		$found = true;
 
-		// Generate HTML markup for the plugin vulnerability.
+		// Generate HTML markup for the nginx vulnerability.
 		$webserver = wpvulnerability_detect_webserver();
 		if ( isset( $webserver['id'] ) && 'nginx' === $webserver['id'] && isset( $webserver['version'] ) && $webserver['version'] ) {
 			// Get the nginx version.
 			$nginx_version = wp_kses( (string) $webserver['version'], 'strip' );
 
 			if ( $nginx_version ) {
-
 				$html .= '<h3>' . esc_html__( 'nginx running', 'wpvulnerability' ) . ': ' . wp_kses( wpvulnerability_sanitize_version_nginx( (string) $nginx_version ), 'strip' ) . '</h3>';
 				$html .= wpvulnerability_html( 'nginx', $nginx['vulnerabilities'] );
-
 			}
 		}
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -351,10 +356,13 @@ function wpvulnerability_list_plugins() {
 	$html  = '<ul class="inside">';
 	$found = false;
 
+	// Get vulnerabilities data for plugins.
 	$plugins = wpvulnerability_plugin_get_vulnerabilities();
 
+	// Iterate through each plugin's data.
 	foreach ( $plugins as $file_path => $plugin_data ) {
 
+		// Check if the plugin is marked as vulnerable.
 		if ( isset( $plugin_data['vulnerable'] ) && 1 === $plugin_data['vulnerable'] ) {
 
 			$found = true;
@@ -367,11 +375,11 @@ function wpvulnerability_list_plugins() {
 
 	$html .= '</ul>';
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -381,33 +389,36 @@ function wpvulnerability_list_plugins() {
  *
  * @version 2.0.0
  *
- * @return string|false The HTML output if plugin vulnerabilities were found, false otherwise.
+ * @return string|false The HTML output if theme vulnerabilities were found, false otherwise.
  */
 function wpvulnerability_html_themes() {
 
 	$html  = '';
 	$found = false;
 
+	// Get vulnerabilities data for themes.
 	$themes = wpvulnerability_theme_get_vulnerabilities();
 
+	// Iterate through each theme's data.
 	foreach ( $themes as $theme_data ) {
 
+		// Check if the theme is marked as vulnerable.
 		if ( isset( $theme_data['wpvulnerability']['vulnerable'] ) && 1 === $theme_data['wpvulnerability']['vulnerable'] ) {
 
-				$found = true;
+			$found = true;
 
-				// Generate HTML markup for the theme vulnerability.
-				$html .= '<h3>' . esc_html__( 'Theme', 'wpvulnerability' ) . ': ' . wp_kses( (string) $theme_data['wpvulnerability']['name'], 'strip' ) . '</h3>';
-				$html .= wpvulnerability_html( 'theme', $theme_data['wpvulnerability']['vulnerabilities'] );
+			// Generate HTML markup for the theme vulnerability.
+			$html .= '<h3>' . esc_html__( 'Theme', 'wpvulnerability' ) . ': ' . wp_kses( (string) $theme_data['wpvulnerability']['name'], 'strip' ) . '</h3>';
+			$html .= wpvulnerability_html( 'theme', $theme_data['wpvulnerability']['vulnerabilities'] );
 
 		}
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
@@ -417,17 +428,20 @@ function wpvulnerability_html_themes() {
  *
  * @version 2.2.0
  *
- * @return string|false The HTML output if plugin vulnerabilities were found, false otherwise.
+ * @return string|false The HTML output if theme vulnerabilities were found, false otherwise.
  */
 function wpvulnerability_list_themes() {
 
 	$html  = '<ul class="inside">';
 	$found = false;
 
+	// Get vulnerabilities data for themes.
 	$themes = wpvulnerability_theme_get_vulnerabilities();
 
+	// Iterate through each theme's data.
 	foreach ( $themes as $theme_data ) {
 
+		// Check if the theme is marked as vulnerable.
 		if ( isset( $theme_data['wpvulnerability']['vulnerable'] ) && 1 === $theme_data['wpvulnerability']['vulnerable'] ) {
 
 			$found = true;
@@ -440,44 +454,45 @@ function wpvulnerability_list_themes() {
 
 	$html .= '</ul>';
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }
 
-
 /**
- * Convert theme vulnerabilities into HTML format.
+ * Convert core vulnerabilities into HTML format.
  *
  * @version 2.0.0
  *
- * @return string|false The HTML output if theme vulnerabilities were found, false otherwise.
+ * @return string|false The HTML output if core vulnerabilities were found, false otherwise.
  */
 function wpvulnerability_html_core() {
 
 	$html  = '';
 	$found = false;
 
+	// Get vulnerabilities data for WordPress core.
 	$core = wpvulnerability_core_get_vulnerabilities();
 
+	// Check if there are any vulnerabilities.
 	if ( is_array( $core ) && count( $core ) ) {
 
 		$found = true;
 
-		// Generate HTML markup for the core vulnerability.
+		// Generate HTML markup for the core vulnerabilities.
 		$html .= wpvulnerability_html( 'core', $core );
 
 	}
 
+	// Return the HTML if vulnerabilities were found.
 	if ( $found ) {
-
 		return $html;
-
 	}
+
 	// Return false if no vulnerabilities were found.
 	return false;
 }

--- a/wpvulnerability-run.php
+++ b/wpvulnerability-run.php
@@ -15,25 +15,27 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  * In a multisite environment, it adds a network admin settings link that appears in the network admin plugin row.
  * For a single site installation, it adds a standard settings link that appears in the plugin row.
  *
+ * @since 3.0.0
+ *
  * @param array $links The links that appear in the plugin row.
  *
  * @return array The modified array of links.
- *
- * @version 3.0.0
  */
 if ( is_multisite() && is_network_admin() ) {
 
 	/**
 	 * Adds a network admin settings link to the plugin row in the network admin plugins list.
 	 *
+	 * @since 3.0.0
+	 *
 	 * @param array $links The links that appear in the network admin plugin row.
 	 *
 	 * @return array The modified array of links.
-	 *
-	 * @version 3.0.0
 	 */
 	function wpvulnerability_add_network_settings_link( $links ) {
-		if ( current_user_can( 'manage_network' ) ) {
+		// Check if the user has the required capabilities to view the settings link.
+		if ( wpvulnerability_capabilities() ) {
+			// Add the network settings link to the plugin row.
 			$links[] = '<a href="' . network_admin_url( 'settings.php?page=wpvulnerability-options' ) . '">' . __( 'Network Settings', 'wpvulnerability' ) . '</a>';
 		}
 		return $links;
@@ -45,24 +47,29 @@ if ( is_multisite() && is_network_admin() ) {
 	/**
 	 * Adds a standard settings link to the plugin row in the plugins list for a single site installation.
 	 *
+	 * @since 2.0.0
+	 *
 	 * @param array $links The links that appear in the plugin row.
 	 *
 	 * @return array The modified array of links.
-	 *
-	 * @version 2.0.0
 	 */
 	function wpvulnerability_add_settings_link( $links ) {
-		if ( current_user_can( 'manage_options' ) ) {
+		// Check if the user has the required capabilities to view the settings link.
+		if ( wpvulnerability_capabilities() ) {
+			// Add the settings link to the plugin row.
 			$links[] = '<a href="' . get_admin_url( null, 'options-general.php?page=wpvulnerability-options' ) . '">' . __( 'Settings', 'wpvulnerability' ) . '</a>';
 		}
 		return $links;
 	}
 	add_filter( 'plugin_action_links_' . WPVULNERABILITY_PLUGIN_BASE, 'wpvulnerability_add_settings_link' );
-
 }
 
 /**
- * Updates the plugin's data
+ * Updates the plugin's data.
+ *
+ * This function updates the vulnerability data for core, plugins, themes, PHP, Apache, and nginx.
+ * It ensures that the required functions are available by including the necessary files.
+ * After updating the vulnerabilities, it flushes the WordPress cache.
  *
  * @since 2.0.0
  *
@@ -70,42 +77,58 @@ if ( is_multisite() && is_network_admin() ) {
  */
 function wpvulnerability_update_database_data() {
 
+	// Ensure the core vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_core_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-core.php';
 	}
+	// Update core vulnerabilities.
+	wpvulnerability_core_get_vulnerabilities_clean();
+
+	// Ensure the plugin vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_plugin_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-plugins.php';
 	}
+	// Update plugin vulnerabilities.
+	wpvulnerability_plugin_get_vulnerabilities_clean();
+
+	// Ensure the theme vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_theme_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-themes.php';
 	}
+	// Update theme vulnerabilities.
+	wpvulnerability_theme_get_vulnerabilities_clean();
+
+	// Ensure the PHP vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_php_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-php.php';
 	}
+	// Update PHP vulnerabilities.
+	wpvulnerability_php_get_vulnerabilities_clean();
+
+	// Ensure the Apache vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_apache_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-apache.php';
 	}
+	// Update Apache vulnerabilities.
+	wpvulnerability_apache_get_vulnerabilities_clean();
+
+	// Ensure the nginx vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_nginx_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-nginx.php';
 	}
-	// Update core vulnerabilities.
-	wpvulnerability_core_get_vulnerabilities_clean();
-	// Update plugin vulnerabilities.
-	wpvulnerability_plugin_get_vulnerabilities_clean();
-	// Update theme vulnerabilities.
-	wpvulnerability_theme_get_vulnerabilities_clean();
-	// Update PHP vulnerabilities.
-	wpvulnerability_php_get_vulnerabilities_clean();
-	// Update Apache vulnerabilities.
-	wpvulnerability_apache_get_vulnerabilities_clean();
 	// Update nginx vulnerabilities.
 	wpvulnerability_nginx_get_vulnerabilities_clean();
+
 	// Clean the WordPress cache.
 	wp_cache_flush();
 }
 
 /**
- * Updates the plugin's data when expired
+ * Updates the plugin's data when expired.
+ *
+ * This function checks if the cached vulnerability data has expired and updates it accordingly.
+ * It ensures that the required functions are available by including the necessary files.
+ * The function handles both multisite and single site installations.
  *
  * @since 3.0.0
  *
@@ -113,64 +136,81 @@ function wpvulnerability_update_database_data() {
  */
 function wpvulnerability_expired_database_data() {
 
+	// Ensure the core vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_core_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-core.php';
 	}
+	// Ensure the plugin vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_plugin_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-plugins.php';
 	}
+	// Ensure the theme vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_theme_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-themes.php';
 	}
+	// Ensure the PHP vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_php_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-php.php';
 	}
+	// Ensure the Apache vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_apache_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-apache.php';
 	}
+	// Ensure the nginx vulnerabilities function is available.
 	if ( ! function_exists( 'wpvulnerability_nginx_get_vulnerabilities_clean' ) ) {
 		require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-nginx.php';
 	}
 
+	// Current time for cache expiration comparison.
 	$cache_time = time();
 
 	if ( is_multisite() ) {
-
+		// Check and update core vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-core-cache' ) ) < $cache_time ) {
 			wpvulnerability_core_get_vulnerabilities_clean();
 		}
+		// Check and update plugin vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-plugins-cache' ) ) < $cache_time ) {
 			wpvulnerability_plugin_get_vulnerabilities_clean();
 		}
+		// Check and update theme vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-themes-cache' ) ) < $cache_time ) {
 			wpvulnerability_theme_get_vulnerabilities_clean();
 		}
+		// Check and update PHP vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-php-cache' ) ) < $cache_time ) {
 			wpvulnerability_php_get_vulnerabilities_clean();
 		}
+		// Check and update Apache vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-apache-cache' ) ) < $cache_time ) {
 			wpvulnerability_apache_get_vulnerabilities_clean();
 		}
+		// Check and update nginx vulnerabilities if cache has expired.
 		if ( json_decode( get_site_option( 'wpvulnerability-nginx-cache' ) ) < $cache_time ) {
 			wpvulnerability_nginx_get_vulnerabilities_clean();
 		}
 	} elseif ( ! is_multisite() ) {
-
+		// Check and update core vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-core-cache' ) ) < $cache_time ) {
 			wpvulnerability_core_get_vulnerabilities_clean();
 		}
+		// Check and update plugin vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-plugins-cache' ) ) < $cache_time ) {
 			wpvulnerability_plugin_get_vulnerabilities_clean();
 		}
+		// Check and update theme vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-themes-cache' ) ) < $cache_time ) {
 			wpvulnerability_theme_get_vulnerabilities_clean();
 		}
+		// Check and update PHP vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-php-cache' ) ) < $cache_time ) {
 			wpvulnerability_php_get_vulnerabilities_clean();
 		}
+		// Check and update Apache vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-apache-cache' ) ) < $cache_time ) {
 			wpvulnerability_apache_get_vulnerabilities_clean();
 		}
+		// Check and update nginx vulnerabilities if cache has expired.
 		if ( json_decode( get_option( 'wpvulnerability-nginx-cache' ) ) < $cache_time ) {
 			wpvulnerability_nginx_get_vulnerabilities_clean();
 		}
@@ -193,11 +233,10 @@ function wpvulnerability_activation() {
 
 		// Add wpvulnerability-config option if it does not exist.
 		if ( ! get_site_option( 'wpvulnerability-config' ) ) {
-
 			$config = get_option( 'wpvulnerability-config' );
 
+			// Check if emails and period are set in the existing config.
 			if ( isset( $config['emails'] ) && $config['emails'] && isset( $config['period'] ) && $config['period'] ) {
-
 				add_site_option(
 					'wpvulnerability-config',
 					array(
@@ -206,9 +245,7 @@ function wpvulnerability_activation() {
 					)
 				);
 				unset( $config );
-
 			} else {
-
 				add_site_option(
 					'wpvulnerability-config',
 					array(
@@ -219,113 +256,41 @@ function wpvulnerability_activation() {
 			}
 		}
 
-		// Add wpvulnerability-plugins option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-plugins' ) ) {
-			add_site_option( 'wpvulnerability-plugins', '' );
-		}
+		// Add other site options if they do not exist.
+		$options = array(
+			'wpvulnerability-plugins'            => '',
+			'wpvulnerability-plugins-cache'      => 0,
+			'wpvulnerability-plugins-vulnerable' => 0,
+			'wpvulnerability-plugins-data'       => '',
+			'wpvulnerability-plugins-data-cache' => 0,
+			'wpvulnerability-themes'             => '',
+			'wpvulnerability-themes-cache'       => 0,
+			'wpvulnerability-themes-vulnerable'  => 0,
+			'wpvulnerability-core'               => '',
+			'wpvulnerability-core-cache'         => 0,
+			'wpvulnerability-core-vulnerable'    => 0,
+			'wpvulnerability-php'                => '',
+			'wpvulnerability-php-cache'          => 0,
+			'wpvulnerability-php-vulnerable'     => 0,
+			'wpvulnerability-apache'             => '',
+			'wpvulnerability-apache-cache'       => 0,
+			'wpvulnerability-apache-vulnerable'  => 0,
+			'wpvulnerability-nginx'              => '',
+			'wpvulnerability-nginx-cache'        => 0,
+			'wpvulnerability-nginx-vulnerable'   => 0,
+		);
 
-		// Add wpvulnerability-plugins-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-plugins-cache' ) ) {
-			add_site_option( 'wpvulnerability-plugins-cache', 0 );
-		}
-
-		// Add wpvulnerability-plugins-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-plugins-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-plugins-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-plugins-data option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-plugins-data' ) ) {
-			add_site_option( 'wpvulnerability-plugins-data', '' );
-		}
-
-		// Add wpvulnerability-plugins-data-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-plugins-data-cache' ) ) {
-			add_site_option( 'wpvulnerability-plugins-data-cache', 0 );
-		}
-
-		// Add wpvulnerability-themes option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-themes' ) ) {
-			add_site_option( 'wpvulnerability-themes', '' );
-		}
-
-		// Add wpvulnerability-themes-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-themes-cache' ) ) {
-			add_site_option( 'wpvulnerability-themes-cache', 0 );
-		}
-
-		// Add wpvulnerability-themes-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-themes-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-themes-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-core option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-core' ) ) {
-			add_site_option( 'wpvulnerability-core', '' );
-		}
-
-		// Add wpvulnerability-core-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-core-cache' ) ) {
-			add_site_option( 'wpvulnerability-core-cache', 0 );
-		}
-
-		// Add wpvulnerability-core-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-core-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-core-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-php option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-php' ) ) {
-			add_site_option( 'wpvulnerability-php', '' );
-		}
-
-		// Add wpvulnerability-php-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-php-cache' ) ) {
-			add_site_option( 'wpvulnerability-php-cache', 0 );
-		}
-
-		// Add wpvulnerability-php-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-php-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-php-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-apache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-apache' ) ) {
-			add_site_option( 'wpvulnerability-apache', '' );
-		}
-
-		// Add wpvulnerability-apache-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-apache-cache' ) ) {
-			add_site_option( 'wpvulnerability-apache-cache', 0 );
-		}
-
-		// Add wpvulnerability-apache-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-apache-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-apache-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-nginx option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-nginx' ) ) {
-			add_site_option( 'wpvulnerability-nginx', '' );
-		}
-
-		// Add wpvulnerability-nginx-cache option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-nginx-cache' ) ) {
-			add_site_option( 'wpvulnerability-nginx-cache', 0 );
-		}
-
-		// Add wpvulnerability-nginx-vulnerable option if it does not exist.
-		if ( ! get_site_option( 'wpvulnerability-nginx-vulnerable' ) ) {
-			add_site_option( 'wpvulnerability-nginx-vulnerable', 0 );
+		foreach ( $options as $key => $value ) {
+			if ( ! get_site_option( $key ) ) {
+				add_site_option( $key, $value );
+			}
 		}
 
 		// Add wpvulnerability-analyze option if it does not exist.
 		if ( ! get_site_option( 'wpvulnerability-analyze' ) ) {
-
 			$analyze = get_option( 'wpvulnerability-analyze' );
 
 			if ( isset( $analyze['core'] ) && isset( $analyze['plugins'] ) && isset( $analyze['themes'] ) && isset( $analyze['php'] ) && isset( $analyze['apache'] ) && isset( $analyze['nginx'] ) ) {
-
 				add_site_option(
 					'wpvulnerability-analyze',
 					array(
@@ -338,9 +303,7 @@ function wpvulnerability_activation() {
 					)
 				);
 				unset( $analyze );
-
 			} else {
-
 				add_site_option(
 					'wpvulnerability-analyze',
 					array(
@@ -367,104 +330,34 @@ function wpvulnerability_activation() {
 			);
 		}
 
-		// Add wpvulnerability-plugins option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-plugins' ) ) {
-			add_option( 'wpvulnerability-plugins', '' );
-		}
+		// Add other options if they do not exist.
+		$options = array(
+			'wpvulnerability-plugins'            => '',
+			'wpvulnerability-plugins-cache'      => 0,
+			'wpvulnerability-plugins-vulnerable' => 0,
+			'wpvulnerability-plugins-data'       => '',
+			'wpvulnerability-plugins-data-cache' => 0,
+			'wpvulnerability-themes'             => '',
+			'wpvulnerability-themes-cache'       => 0,
+			'wpvulnerability-themes-vulnerable'  => 0,
+			'wpvulnerability-core'               => '',
+			'wpvulnerability-core-cache'         => 0,
+			'wpvulnerability-core-vulnerable'    => 0,
+			'wpvulnerability-php'                => '',
+			'wpvulnerability-php-cache'          => 0,
+			'wpvulnerability-php-vulnerable'     => 0,
+			'wpvulnerability-apache'             => '',
+			'wpvulnerability-apache-cache'       => 0,
+			'wpvulnerability-apache-vulnerable'  => 0,
+			'wpvulnerability-nginx'              => '',
+			'wpvulnerability-nginx-cache'        => 0,
+			'wpvulnerability-nginx-vulnerable'   => 0,
+		);
 
-		// Add wpvulnerability-plugins-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-plugins-cache' ) ) {
-			add_option( 'wpvulnerability-plugins-cache', 0 );
-		}
-
-		// Add wpvulnerability-plugins-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-plugins-vulnerable' ) ) {
-			add_option( 'wpvulnerability-plugins-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-plugins-data option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-plugins-data' ) ) {
-			add_option( 'wpvulnerability-plugins-data', '' );
-		}
-
-		// Add wpvulnerability-plugins-data-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-plugins-data-cache' ) ) {
-			add_option( 'wpvulnerability-plugins-data-cache', 0 );
-		}
-
-		// Add wpvulnerability-themes option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-themes' ) ) {
-			add_option( 'wpvulnerability-themes', '' );
-		}
-
-		// Add wpvulnerability-themes-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-themes-cache' ) ) {
-			add_option( 'wpvulnerability-themes-cache', 0 );
-		}
-
-		// Add wpvulnerability-themes-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-themes-vulnerable' ) ) {
-			add_option( 'wpvulnerability-themes-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-core option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-core' ) ) {
-			add_option( 'wpvulnerability-core', '' );
-		}
-
-		// Add wpvulnerability-core-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-core-cache' ) ) {
-			add_option( 'wpvulnerability-core-cache', 0 );
-		}
-
-		// Add wpvulnerability-core-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-core-vulnerable' ) ) {
-			add_option( 'wpvulnerability-core-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-php option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-php' ) ) {
-			add_option( 'wpvulnerability-php', '' );
-		}
-
-		// Add wpvulnerability-php-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-php-cache' ) ) {
-			add_option( 'wpvulnerability-php-cache', 0 );
-		}
-
-		// Add wpvulnerability-php-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-php-vulnerable' ) ) {
-			add_option( 'wpvulnerability-php-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-apache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-apache' ) ) {
-			add_option( 'wpvulnerability-apache', '' );
-		}
-
-		// Add wpvulnerability-apache-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-apache-cache' ) ) {
-			add_option( 'wpvulnerability-apache-cache', 0 );
-		}
-
-		// Add wpvulnerability-apache-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-apache-vulnerable' ) ) {
-			add_option( 'wpvulnerability-apache-vulnerable', 0 );
-		}
-
-		// Add wpvulnerability-nginx option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-nginx' ) ) {
-			add_option( 'wpvulnerability-nginx', '' );
-		}
-
-		// Add wpvulnerability-nginx-cache option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-nginx-cache' ) ) {
-			add_option( 'wpvulnerability-nginx-cache', 0 );
-		}
-
-		// Add wpvulnerability-nginx-vulnerable option if it does not exist.
-		if ( ! get_option( 'wpvulnerability-nginx-vulnerable' ) ) {
-			add_option( 'wpvulnerability-nginx-vulnerable', 0 );
+		foreach ( $options as $key => $value ) {
+			if ( ! get_option( $key ) ) {
+				add_option( $key, $value );
+			}
 		}
 
 		// Add wpvulnerability-config option if it does not exist.
@@ -486,7 +379,7 @@ function wpvulnerability_activation() {
 
 /**
  * On Deactivation
- * Callback function to run when the plugin is deactivated
+ * Callback function to run when the plugin is deactivated.
  * Deletes options and removes scheduled wp-cron jobs.
  *
  * @since 2.0.0
@@ -497,56 +390,64 @@ function wpvulnerability_deactivation() {
 
 	if ( is_multisite() ) {
 
-		// Delete all plugin options.
-		delete_site_option( 'wpvulnerability_settings' );
-		delete_site_option( 'wpvulnerability-data' );
-		delete_site_option( 'wpvulnerability-analyze' );
+		// Delete all plugin options for multisite.
+		$multisite_options = array(
+			'wpvulnerability_settings',
+			'wpvulnerability-data',
+			'wpvulnerability-analyze',
+			'wpvulnerability-themes',
+			'wpvulnerability-themes-cache',
+			'wpvulnerability-themes-vulnerable',
+			'wpvulnerability-plugins',
+			'wpvulnerability-plugins-cache',
+			'wpvulnerability-plugins-vulnerable',
+			'wpvulnerability-core',
+			'wpvulnerability-core-cache',
+			'wpvulnerability-core-vulnerable',
+			'wpvulnerability-php',
+			'wpvulnerability-php-cache',
+			'wpvulnerability-php-vulnerable',
+			'wpvulnerability-apache',
+			'wpvulnerability-apache-cache',
+			'wpvulnerability-apache-vulnerable',
+			'wpvulnerability-nginx',
+			'wpvulnerability-nginx-cache',
+			'wpvulnerability-nginx-vulnerable',
+		);
 
-		delete_site_option( 'wpvulnerability-themes' );
-		delete_site_option( 'wpvulnerability-themes-cache' );
-		delete_site_option( 'wpvulnerability-themes-vulnerable' );
-		delete_site_option( 'wpvulnerability-plugins' );
-		delete_site_option( 'wpvulnerability-plugins-cache' );
-		delete_site_option( 'wpvulnerability-plugins-vulnerable' );
-		delete_site_option( 'wpvulnerability-core' );
-		delete_site_option( 'wpvulnerability-core-cache' );
-		delete_site_option( 'wpvulnerability-core-vulnerable' );
-		delete_site_option( 'wpvulnerability-php' );
-		delete_site_option( 'wpvulnerability-php-cache' );
-		delete_site_option( 'wpvulnerability-php-vulnerable' );
-		delete_site_option( 'wpvulnerability-apache' );
-		delete_site_option( 'wpvulnerability-apache-cache' );
-		delete_site_option( 'wpvulnerability-apache-vulnerable' );
-		delete_site_option( 'wpvulnerability-nginx' );
-		delete_site_option( 'wpvulnerability-nginx-cache' );
-		delete_site_option( 'wpvulnerability-nginx-vulnerable' );
+		foreach ( $multisite_options as $option ) {
+			delete_site_option( $option );
+		}
+	} else {
 
-	} elseif ( ! is_multisite() ) {
+		// Delete all plugin options for single site.
+		$single_site_options = array(
+			'wpvulnerability_settings',
+			'wpvulnerability-data',
+			'wpvulnerability-analyze',
+			'wpvulnerability-themes',
+			'wpvulnerability-themes-cache',
+			'wpvulnerability-themes-vulnerable',
+			'wpvulnerability-plugins',
+			'wpvulnerability-plugins-cache',
+			'wpvulnerability-plugins-vulnerable',
+			'wpvulnerability-core',
+			'wpvulnerability-core-cache',
+			'wpvulnerability-core-vulnerable',
+			'wpvulnerability-php',
+			'wpvulnerability-php-cache',
+			'wpvulnerability-php-vulnerable',
+			'wpvulnerability-apache',
+			'wpvulnerability-apache-cache',
+			'wpvulnerability-apache-vulnerable',
+			'wpvulnerability-nginx',
+			'wpvulnerability-nginx-cache',
+			'wpvulnerability-nginx-vulnerable',
+		);
 
-		// Delete all plugin options.
-		delete_option( 'wpvulnerability_settings' );
-		delete_option( 'wpvulnerability-data' );
-		delete_option( 'wpvulnerability-analyze' );
-
-		delete_option( 'wpvulnerability-themes' );
-		delete_option( 'wpvulnerability-themes-cache' );
-		delete_option( 'wpvulnerability-themes-vulnerable' );
-		delete_option( 'wpvulnerability-plugins' );
-		delete_option( 'wpvulnerability-plugins-cache' );
-		delete_option( 'wpvulnerability-plugins-vulnerable' );
-		delete_option( 'wpvulnerability-core' );
-		delete_option( 'wpvulnerability-core-cache' );
-		delete_option( 'wpvulnerability-core-vulnerable' );
-		delete_option( 'wpvulnerability-php' );
-		delete_option( 'wpvulnerability-php-cache' );
-		delete_option( 'wpvulnerability-php-vulnerable' );
-		delete_option( 'wpvulnerability-apache' );
-		delete_option( 'wpvulnerability-apache-cache' );
-		delete_option( 'wpvulnerability-apache-vulnerable' );
-		delete_option( 'wpvulnerability-nginx' );
-		delete_option( 'wpvulnerability-nginx-cache' );
-		delete_option( 'wpvulnerability-nginx-vulnerable' );
-
+		foreach ( $single_site_options as $option ) {
+			delete_option( $option );
+		}
 	}
 
 	// Unschedule and remove scheduled wp-cron jobs.
@@ -562,7 +463,7 @@ function wpvulnerability_deactivation() {
 
 /**
  * On Uninstall
- * Callback function to run when the plugin is uninstalled
+ * Callback function to run when the plugin is uninstalled.
  * Deletes options and removes scheduled wp-cron jobs.
  *
  * @since 3.0.0
@@ -571,68 +472,68 @@ function wpvulnerability_deactivation() {
  */
 function wpvulnerability_uninstall() {
 
-	/**
-	 * Deprecated options.
-	 */
+	// Deprecated options.
 	delete_option( 'wpvulnerability_settings' );
 	delete_option( 'wpvulnerability-data' );
 
-	/**
-	 * All the data.
-	 */
-	delete_option( 'wpvulnerability-themes' );
-	delete_option( 'wpvulnerability-themes-cache' );
-	delete_option( 'wpvulnerability-themes-vulnerable' );
-	delete_option( 'wpvulnerability-plugins' );
-	delete_option( 'wpvulnerability-plugins-cache' );
-	delete_option( 'wpvulnerability-plugins-vulnerable' );
-	delete_option( 'wpvulnerability-core' );
-	delete_option( 'wpvulnerability-core-cache' );
-	delete_option( 'wpvulnerability-core-vulnerable' );
-	delete_option( 'wpvulnerability-php' );
-	delete_option( 'wpvulnerability-php-cache' );
-	delete_option( 'wpvulnerability-php-vulnerable' );
-	delete_option( 'wpvulnerability-apache' );
-	delete_option( 'wpvulnerability-apache-cache' );
-	delete_option( 'wpvulnerability-apache-vulnerable' );
-	delete_option( 'wpvulnerability-nginx' );
-	delete_option( 'wpvulnerability-nginx-cache' );
-	delete_option( 'wpvulnerability-nginx-vulnerable' );
+	// Delete all plugin data options.
+	$options = array(
+		'wpvulnerability-themes',
+		'wpvulnerability-themes-cache',
+		'wpvulnerability-themes-vulnerable',
+		'wpvulnerability-plugins',
+		'wpvulnerability-plugins-cache',
+		'wpvulnerability-plugins-vulnerable',
+		'wpvulnerability-core',
+		'wpvulnerability-core-cache',
+		'wpvulnerability-core-vulnerable',
+		'wpvulnerability-php',
+		'wpvulnerability-php-cache',
+		'wpvulnerability-php-vulnerable',
+		'wpvulnerability-apache',
+		'wpvulnerability-apache-cache',
+		'wpvulnerability-apache-vulnerable',
+		'wpvulnerability-nginx',
+		'wpvulnerability-nginx-cache',
+		'wpvulnerability-nginx-vulnerable',
+		'wpvulnerability-analyze',
+	);
 
-	delete_option( 'wpvulnerability-analyze' );
+	foreach ( $options as $option ) {
+		delete_option( $option );
+	}
 
-	/**
-	 * Config data, not deleted when deactivated.
-	 */
+	// Config data, not deleted when deactivated.
 	delete_option( 'wpvulnerability-config' );
 
-	/**
-	 * All the data (Multisite).
-	 */
-	delete_site_option( 'wpvulnerability-themes' );
-	delete_site_option( 'wpvulnerability-themes-cache' );
-	delete_site_option( 'wpvulnerability-themes-vulnerable' );
-	delete_site_option( 'wpvulnerability-plugins' );
-	delete_site_option( 'wpvulnerability-plugins-cache' );
-	delete_site_option( 'wpvulnerability-plugins-vulnerable' );
-	delete_site_option( 'wpvulnerability-core' );
-	delete_site_option( 'wpvulnerability-core-cache' );
-	delete_site_option( 'wpvulnerability-core-vulnerable' );
-	delete_site_option( 'wpvulnerability-php' );
-	delete_site_option( 'wpvulnerability-php-cache' );
-	delete_site_option( 'wpvulnerability-php-vulnerable' );
-	delete_site_option( 'wpvulnerability-apache' );
-	delete_site_option( 'wpvulnerability-apache-cache' );
-	delete_site_option( 'wpvulnerability-apache-vulnerable' );
-	delete_site_option( 'wpvulnerability-nginx' );
-	delete_site_option( 'wpvulnerability-nginx-cache' );
-	delete_site_option( 'wpvulnerability-nginx-vulnerable' );
+	// Delete all multisite options.
+	$multisite_options = array(
+		'wpvulnerability-themes',
+		'wpvulnerability-themes-cache',
+		'wpvulnerability-themes-vulnerable',
+		'wpvulnerability-plugins',
+		'wpvulnerability-plugins-cache',
+		'wpvulnerability-plugins-vulnerable',
+		'wpvulnerability-core',
+		'wpvulnerability-core-cache',
+		'wpvulnerability-core-vulnerable',
+		'wpvulnerability-php',
+		'wpvulnerability-php-cache',
+		'wpvulnerability-php-vulnerable',
+		'wpvulnerability-apache',
+		'wpvulnerability-apache-cache',
+		'wpvulnerability-apache-vulnerable',
+		'wpvulnerability-nginx',
+		'wpvulnerability-nginx-cache',
+		'wpvulnerability-nginx-vulnerable',
+		'wpvulnerability-analyze',
+	);
 
-	delete_site_option( 'wpvulnerability-analyze' );
+	foreach ( $multisite_options as $option ) {
+		delete_site_option( $option );
+	}
 
-	/**
-	 * Config data (Multisite), not deleted when deactivated.
-	 */
+	// Config data (Multisite), not deleted when deactivated.
 	delete_site_option( 'wpvulnerability-config' );
 
 	// Unschedule and remove scheduled wp-cron jobs.
@@ -659,12 +560,14 @@ function wpvulnerability_uninstall() {
  */
 function wpvulnerability_analyze_filter( $type ) {
 
+	// Retrieve the analysis settings based on the WordPress setup.
 	if ( ! is_multisite() ) {
 		$wpvulnerability_analyze = get_option( 'wpvulnerability-analyze', array() );
 	} elseif ( is_multisite() ) {
 		$wpvulnerability_analyze = get_site_option( 'wpvulnerability-analyze', array() );
 	}
 
+	// Check the specified type and return the appropriate value.
 	switch ( $type ) {
 		case 'core':
 			if ( isset( $wpvulnerability_analyze['core'] ) && (int) $wpvulnerability_analyze['core'] ) {
@@ -672,47 +575,39 @@ function wpvulnerability_analyze_filter( $type ) {
 			} else {
 				return true;
 			}
-			break;
 		case 'plugins':
 			if ( isset( $wpvulnerability_analyze['plugins'] ) && (int) $wpvulnerability_analyze['plugins'] ) {
 				return false;
 			} else {
 				return true;
 			}
-			break;
 		case 'themes':
 			if ( isset( $wpvulnerability_analyze['themes'] ) && (int) $wpvulnerability_analyze['themes'] ) {
 				return false;
 			} else {
 				return true;
 			}
-			break;
 		case 'php':
 			if ( isset( $wpvulnerability_analyze['php'] ) && (int) $wpvulnerability_analyze['php'] ) {
 				return false;
 			} else {
 				return true;
 			}
-			break;
 		case 'apache':
 			if ( isset( $wpvulnerability_analyze['apache'] ) && (int) $wpvulnerability_analyze['apache'] ) {
 				return false;
 			} else {
 				return true;
 			}
-			break;
 		case 'nginx':
 			if ( isset( $wpvulnerability_analyze['nginx'] ) && (int) $wpvulnerability_analyze['nginx'] ) {
 				return false;
 			} else {
 				return true;
 			}
-			break;
 		default:
 			return true;
 	}
-
-	return true;
 }
 
 /**

--- a/wpvulnerability-schedule.php
+++ b/wpvulnerability-schedule.php
@@ -19,10 +19,12 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  */
 if ( ! wp_next_scheduled( 'wpvulnerability_update_database' ) ) {
 
+	// Schedule the event only for the main site in a multisite network or for a single site.
 	if ( ( ! is_multisite() ) || ( is_multisite() && is_main_site() ) ) {
 		wp_schedule_event( time(), 'twicedaily', 'wpvulnerability_update_database' );
 	}
 }
+// Hook the event to the function that updates the database.
 add_action( 'wpvulnerability_update_database', 'wpvulnerability_update_database_data' );
 
 /**
@@ -55,4 +57,5 @@ if ( isset( $wpvulnerability_s['period'] ) ) {
 	add_action( 'wpvulnerability_notification', 'wpvulnerability_execute_notification' );
 
 }
+// Clean up.
 unset( $wpvulnerability_s );

--- a/wpvulnerability-sitehealth.php
+++ b/wpvulnerability-sitehealth.php
@@ -52,13 +52,14 @@ function wpvulnerability_test_plugins() {
 			wpvulnerability_html_plugins()
 		);
 
+		// Add action links to update plugins.
 		if ( is_multisite() ) {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( network_admin_url( 'plugins.php' ) ),
 				__( 'Update plugins', 'wpvulnerability' )
 			);
-		} elseif ( ! is_multisite() ) {
+		} else {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'plugins.php' ) ),
@@ -98,7 +99,7 @@ function wpvulnerability_test_themes() {
 	// Check if any theme vulnerabilities were found.
 	if ( is_multisite() ) {
 		$wpvulnerability_test_themes_counter = json_decode( get_site_option( 'wpvulnerability-themes-vulnerable' ) );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$wpvulnerability_test_themes_counter = json_decode( get_option( 'wpvulnerability-themes-vulnerable' ) );
 	}
 
@@ -113,13 +114,14 @@ function wpvulnerability_test_themes() {
 			wpvulnerability_html_themes()
 		);
 
+		// Add action links to update themes.
 		if ( is_multisite() ) {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( network_admin_url( 'themes.php' ) ),
 				__( 'Update themes', 'wpvulnerability' )
 			);
-		} elseif ( ! is_multisite() ) {
+		} else {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'themes.php' ) ),
@@ -159,9 +161,10 @@ function wpvulnerability_test_core() {
 	// Check if any core vulnerabilities were found.
 	if ( is_multisite() ) {
 		$wpvulnerability_test_core_counter = json_decode( get_site_option( 'wpvulnerability-core-vulnerable' ) );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$wpvulnerability_test_core_counter = json_decode( get_option( 'wpvulnerability-core-vulnerable' ) );
 	}
+
 	if ( $wpvulnerability_test_core_counter ) {
 		$result['status'] = 'critical';
 		/* translators: Site Health message */
@@ -173,13 +176,14 @@ function wpvulnerability_test_core() {
 			wpvulnerability_html_core()
 		);
 
+		// Add action links to update WordPress.
 		if ( is_multisite() ) {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( network_admin_url( 'update-core.php' ) ),
 				__( 'Update WordPress', 'wpvulnerability' )
 			);
-		} elseif ( ! is_multisite() ) {
+		} else {
 			$result['actions'] .= sprintf(
 				'<p><a href="%s">%s</a></p>',
 				esc_url( admin_url( 'update-core.php' ) ),
@@ -219,7 +223,7 @@ function wpvulnerability_test_php() {
 	// Check if any PHP vulnerabilities were found.
 	if ( is_multisite() ) {
 		$wpvulnerability_test_php_counter = json_decode( get_site_option( 'wpvulnerability-php-vulnerable' ) );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$wpvulnerability_test_php_counter = json_decode( get_option( 'wpvulnerability-php-vulnerable' ) );
 	}
 
@@ -271,7 +275,7 @@ function wpvulnerability_test_apache() {
 	// Check if any Apache vulnerabilities were found.
 	if ( is_multisite() ) {
 		$wpvulnerability_test_apache_counter = json_decode( get_site_option( 'wpvulnerability-apache-vulnerable' ) );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$wpvulnerability_test_apache_counter = json_decode( get_option( 'wpvulnerability-apache-vulnerable' ) );
 	}
 
@@ -318,7 +322,7 @@ function wpvulnerability_test_nginx() {
 	// Check if any nginx vulnerabilities were found.
 	if ( is_multisite() ) {
 		$wpvulnerability_test_nginx_counter = json_decode( get_site_option( 'wpvulnerability-nginx-vulnerable' ) );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$wpvulnerability_test_nginx_counter = json_decode( get_option( 'wpvulnerability-nginx-vulnerable' ) );
 	}
 

--- a/wpvulnerability-themes.php
+++ b/wpvulnerability-themes.php
@@ -133,7 +133,7 @@ function wpvulnerability_theme_info_after( $theme_file, $theme_data ) {
  *
  * @return array The updated theme data array.
  */
-function get_fresh_theme_vulnerabilities( $theme_data, $theme_slug ) {
+function wpvulnerability_get_fresh_theme_vulnerabilities( $theme_data, $theme_slug ) {
 
 	// Get the theme version and slug from the theme data.
 	$theme_version        = wp_kses( (string) $theme_data['data']->get( 'Version' ), 'strip' );
@@ -147,7 +147,7 @@ function get_fresh_theme_vulnerabilities( $theme_data, $theme_slug ) {
 	// Retrieve vulnerabilities for the theme using its slug and version.
 	if ( $theme_slug ) {
 
-		$theme_api_response = wpvulnerability_get_theme( $theme_slug, $theme_version );
+		$theme_api_response = wpvulnerability_get_theme( $theme_slug, $theme_version, 0 );
 
 		// If vulnerabilities are found, update the theme data accordingly.
 		if ( ! empty( $theme_api_response ) ) {
@@ -179,7 +179,7 @@ function wpvulnerability_theme_get_installed() {
 	foreach ( $themes as $slug => $theme_data ) {
 
 		$themes_v[ $slug ]['data']            = $theme_data;
-		$themes_v[ $slug ]['wpvulnerability'] = get_fresh_theme_vulnerabilities( $themes_v[ $slug ], $slug );
+		$themes_v[ $slug ]['wpvulnerability'] = wpvulnerability_get_fresh_theme_vulnerabilities( $themes_v[ $slug ], $slug );
 
 		if ( isset( $themes_v[ $slug ]['wpvulnerability']['vulnerable'] ) && (int) $themes_v[ $slug ]['wpvulnerability']['vulnerable'] ) {
 

--- a/wpvulnerability-themes.php
+++ b/wpvulnerability-themes.php
@@ -285,13 +285,7 @@ function wpvulnerability_theme_page() {
 
 	// Check if the current page is the plugins page.
 	global $pagenow;
-	if (
-		wpvulnerability_analyze_filter( 'themes' ) && 'themes.php' === $pagenow &&
-		(
-			( is_multisite() && is_network_admin() && current_user_can( 'manage_network' ) ) ||
-			( ! is_multisite() && is_admin() && current_user_can( 'manage_options' ) )
-		)
-	) {
+	if ( wpvulnerability_analyze_filter( 'themes' ) && 'themes.php' === $pagenow && wpvulnerability_capabilities() ) {
 
 		// Get the vulnerabilities for the installed themes.
 		$themes = wpvulnerability_theme_get_vulnerabilities();

--- a/wpvulnerability-themes.php
+++ b/wpvulnerability-themes.php
@@ -14,8 +14,8 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
  *
  * @since 2.0.0
  *
- * @param  string $theme_file Main themes folder/file name.
- * @param  array  $theme_data Plugin data.
+ * @param string $theme_file Main themes folder/file name.
+ * @param array  $theme_data Theme data.
  *
  * @return void
  */
@@ -24,7 +24,7 @@ function wpvulnerability_theme_info_after( $theme_file, $theme_data ) {
 	// Retrieve the vulnerabilities for all themes from the options table and decode the JSON.
 	if ( is_multisite() ) {
 		$theme_vulnerabilities = json_decode( get_site_option( 'wpvulnerability-themes' ), true );
-	} elseif ( ! is_multisite() ) {
+	} else {
 		$theme_vulnerabilities = json_decode( get_option( 'wpvulnerability-themes' ), true );
 	}
 
@@ -45,8 +45,7 @@ function wpvulnerability_theme_info_after( $theme_file, $theme_data ) {
 	// Begin generating the table row HTML markup with appropriate CSS classes and the vulnerability notice message.
 	$information  = '<tr class="wpvulnerability ' . $tr_class . '">';
 	$information .= '<td colspan="4">';
-	$information .= '<p class="text-red"><img src="' . esc_url( WPVULNERABILITY_PLUGIN_URL ) . 'assets/logo16.png" style="height: 16px; vertical-align: text-top; width: 16px;" alt="" title="WPVulnerability"> <strong>' . $message . '</strong>';
-	$information .= '</p>';
+	$information .= '<p class="text-red"><img src="' . esc_url( WPVULNERABILITY_PLUGIN_URL ) . 'assets/logo16.png" style="height: 16px; vertical-align: text-top; width: 16px;" alt="" title="WPVulnerability"> <strong>' . $message . '</strong></p>';
 	$information .= '<table>';
 
 	// Loop through all vulnerabilities for the current theme and add their details to the table row HTML markup.
@@ -167,7 +166,7 @@ function wpvulnerability_get_fresh_theme_vulnerabilities( $theme_data, $theme_sl
  *
  * @since 2.0.0
  *
- * @return string JSON-encoded array of plugin data with vulnerabilities and vulnerable status
+ * @return string JSON-encoded array of theme data with vulnerabilities and vulnerable status
  */
 function wpvulnerability_theme_get_installed() {
 
@@ -178,26 +177,29 @@ function wpvulnerability_theme_get_installed() {
 
 	foreach ( $themes as $slug => $theme_data ) {
 
-		$themes_v[ $slug ]['data']            = $theme_data;
+		// Store the theme data.
+		$themes_v[ $slug ]['data'] = $theme_data;
+
+		// Get fresh vulnerabilities for the theme.
 		$themes_v[ $slug ]['wpvulnerability'] = wpvulnerability_get_fresh_theme_vulnerabilities( $themes_v[ $slug ], $slug );
 
+		// If the theme is vulnerable, increment the vulnerable themes counter.
 		if ( isset( $themes_v[ $slug ]['wpvulnerability']['vulnerable'] ) && (int) $themes_v[ $slug ]['wpvulnerability']['vulnerable'] ) {
-
 			++$wpvulnerability_themes_vulnerable;
-
 		}
 	}
 
+	// Update options for multisite.
 	if ( is_multisite() ) {
-
 		update_site_option( 'wpvulnerability-themes', wp_json_encode( $themes_v ) );
 		update_site_option( 'wpvulnerability-themes-vulnerable', wp_json_encode( number_format( $wpvulnerability_themes_vulnerable, 0, '.', '' ) ) );
+		update_site_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 
+		// Update options for single site.
 	} elseif ( ! is_multisite() ) {
-
 		update_option( 'wpvulnerability-themes', wp_json_encode( $themes_v ) );
 		update_option( 'wpvulnerability-themes-vulnerable', wp_json_encode( number_format( $wpvulnerability_themes_vulnerable, 0, '.', '' ) ) );
-
+		update_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
 	}
 
 	return wp_json_encode( $themes_v );
@@ -208,7 +210,7 @@ function wpvulnerability_theme_get_installed() {
  *
  * @since 2.0.0
  *
- * @return array Array of installed plugins with their vulnerabilities.
+ * @return array Array of installed themes with their vulnerabilities.
  */
 function wpvulnerability_theme_get_vulnerabilities() {
 
@@ -220,7 +222,7 @@ function wpvulnerability_theme_get_vulnerabilities() {
 		// Get the installed theme data and decode it.
 		$theme_data = json_decode( get_site_option( 'wpvulnerability-themes' ), true );
 
-	} elseif ( ! is_multisite() ) {
+	} else {
 
 		// Get the cached theme data and decode it.
 		$theme_data_cache = json_decode( get_option( 'wpvulnerability-themes-cache' ) );
@@ -236,15 +238,6 @@ function wpvulnerability_theme_get_vulnerabilities() {
 		// Get the installed theme data and update the cache.
 		$theme_data = json_decode( wpvulnerability_theme_get_installed(), true );
 
-		if ( is_multisite() ) {
-
-			update_site_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		} elseif ( ! is_multisite() ) {
-
-			update_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-		}
 	}
 
 	return $theme_data;
@@ -261,16 +254,6 @@ function wpvulnerability_theme_get_vulnerabilities_clean() {
 
 	// Update the installed themes cache.
 	wpvulnerability_theme_get_installed();
-
-	if ( is_multisite() ) {
-
-		update_site_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	} elseif ( ! is_multisite() ) {
-
-		update_option( 'wpvulnerability-themes-cache', wp_json_encode( number_format( time() + ( 3600 * WPVULNERABILITY_CACHE_HOURS ), 0, '.', '' ) ) );
-
-	}
 }
 
 /**
@@ -283,23 +266,23 @@ function wpvulnerability_theme_get_vulnerabilities_clean() {
  */
 function wpvulnerability_theme_page() {
 
-	// Check if the current page is the plugins page.
+	// Check if the current page is the themes page.
 	global $pagenow;
 	if ( wpvulnerability_analyze_filter( 'themes' ) && 'themes.php' === $pagenow && wpvulnerability_capabilities() ) {
 
 		// Get the vulnerabilities for the installed themes.
 		$themes = wpvulnerability_theme_get_vulnerabilities();
 
-		// Loop through the plugins and add vulnerability information after the plugin row for vulnerable plugins.
+		// Loop through the themes and add vulnerability information after the theme row for vulnerable themes.
 		foreach ( $themes as $theme_file => $theme_data ) {
 
 			if ( isset( $theme_data['wpvulnerability']['vulnerable'] ) && 1 === $theme_data['wpvulnerability']['vulnerable'] ) {
 
-				add_action( 'after_theme_row_' . $theme_file, 'wpvulnerability_theme_info_after', 10, 3 );
+				add_action( 'after_theme_row_' . $theme_file, 'wpvulnerability_theme_info_after', 10, 2 );
 
 			}
 		}
 	}
 }
-// Add notices for vulnerable plugins on the plugin page.
+// Add notices for vulnerable themes on the theme page.
 add_action( 'admin_head', 'wpvulnerability_theme_page' );


### PR DESCRIPTION
**CACHE**

There were some problems reading the API and the data. Now, the Reload Data and the Load Data works in a way where every part saves the cache where it's time and does not use old information.

Probably this new way will ask more to the API, but the user will have refreshed information where it supposed to have it.

**WP-CLI**

Get the arguments via command (the --format=table and --format=json), and allow showing the data in a more sensed way for the different types of vulnerabilities: core, themes, plugins, php, apache and nginx.
