### PR TITLE
v3.3.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,24 @@
 == Changelog ==
 
+= [3.3.1] - 2024-08-02 =
+
+**Fix**
+
+* Delete the wp_is_rest_endpoint check. Does not need it.
+
+**Compatibility**
+
+* WordPress: 4.1 - 6.7
+* PHP: 5.6 - 8.3
+* WP-CLI: 2.3.0 - 2.10.0
+
+**Tests**
+
+* PHP Coding Standards: 3.10.2
+* WordPress Coding Standards: 3.1.0
+* Plugin Check (PCP): 1.0.2
+* SonarCloud Code Review
+
 = [3.3.0] - 2024-08-02 =
 
 **Added**

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: javiercasares, davidperez, lbonomo, alexclassroom
 Tags: security, vulnerability, site-health
 Requires at least: 4.1
 Tested up to: 6.7
-Stable tag: 3.3.0
+Stable tag: 3.3.1
 Requires PHP: 5.6
-Version: 3.3.0
+Version: 3.3.1
 License: GPL-2.0-or-later
 License URI: https://spdx.org/licenses/GPL-2.0-or-later.html
 
@@ -115,6 +115,25 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 
 == Changelog ==
 
+= [3.3.1] - 2024-08-02 =
+
+**Fix**
+
+* Delete the wp_is_rest_endpoint check. Does not need it.
+
+**Compatibility**
+
+* WordPress: 4.1 - 6.7
+* PHP: 5.6 - 8.3
+* WP-CLI: 2.3.0 - 2.10.0
+
+**Tests**
+
+* PHP Coding Standards: 3.10.2
+* WordPress Coding Standards: 3.1.0
+* Plugin Check (PCP): 1.0.2
+* SonarCloud Code Review
+
 = [3.3.0] - 2024-08-02 =
 
 **Added**
@@ -168,21 +187,6 @@ First of all, peace of mind. Investigate what the vulnerability is and, above al
 * Plugin Check (PCP): 1.0.2
 * SonarCloud Code Review
 
-= [3.2.0] - 2024-05-08 =
-
-**Added**
-
-* Apache HTTPD vulnerabilities (Site Health).
-* nginx vulnerabilities (Site Health).
-
-**Compatibility**
-
-* WordPress 4.1 - WordPress 6.6.
-* PHP 5.6 - PHP 8.3.
-* WordPress Coding Standards 3.1.0.
-* WP-CLI 2.3.0 - WP-CLI 2.10.0.
-* Plugin Check (PCP)
-
 = Previous versions =
 
 If you want to see the full changelog, visit the [changelog.txt](https://plugins.trac.wordpress.org/browser/wpvulnerability/trunk/changelog.txt) file.
@@ -203,7 +207,7 @@ This plugin adheres to the following security measures and review protocols for 
 
 == Vulnerabilities ==
 
-* No vulnerabilities have been published up to version 3.3.0.
+* No vulnerabilities have been published up to version 3.3.1.
 
 Found a security vulnerability? Please report it to us privately at the [WPVulnerability GitHub repository](https://github.com/javiercasares/wpvulnerability/security/advisories/new).
 

--- a/wpvulnerability.php
+++ b/wpvulnerability.php
@@ -5,7 +5,7 @@
  * Description: Receive information about possible vulnerabilities in your WordPress from WordPress Vulnerability Database API.
  * Requires at least: 4.1
  * Requires PHP: 5.6
- * Version: 3.3.0
+ * Version: 3.3.1
  * Author: Javier Casares
  * Author URI: https://www.javiercasares.com/
  * License: GPL-2.0-or-later
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 /**
  * Set some constants that I can change in future verions
  */
-define( 'WPVULNERABILITY_PLUGIN_VERSION', '3.3.0' );
+define( 'WPVULNERABILITY_PLUGIN_VERSION', '3.3.1' );
 define( 'WPVULNERABILITY_API_HOST', 'https://www.wpvulnerability.net/' );
 define( 'WPVULNERABILITY_CACHE_HOURS', 12 );
 
@@ -98,7 +98,7 @@ function wpvulnerability_plugin_init() {
 /*
  * Only load if it's admin / super admin
  */
-if ( ( ! is_multisite() && is_admin() ) || ( is_multisite() && ( is_network_admin() || is_main_site() ) ) || ( defined( 'WP_CLI' ) && WP_CLI ) || wp_doing_cron() || wp_is_rest_endpoint() ) {
+if ( ( ! is_multisite() && is_admin() ) || ( is_multisite() && ( is_network_admin() || is_main_site() ) ) || ( defined( 'WP_CLI' ) && WP_CLI ) || wp_doing_cron() ) {
 
 	require_once WPVULNERABILITY_PLUGIN_PATH . '/wpvulnerability-run.php';
 	register_activation_hook( WPVULNERABILITY_PLUGIN_FILE, 'wpvulnerability_activation' );


### PR DESCRIPTION
= [3.3.1] - 2024-08-02 =

**Fix**

* Delete the wp_is_rest_endpoint check. Does not need it.

**Compatibility**

* WordPress: 4.1 - 6.7
* PHP: 5.6 - 8.3
* WP-CLI: 2.3.0 - 2.10.0

**Tests**

* PHP Coding Standards: 3.10.2
* WordPress Coding Standards: 3.1.0
* Plugin Check (PCP): 1.0.2
* SonarCloud Code Review
