### PR TITLE
Fixed PHP fatal error due to summing undefined variables.

### DIFF
--- a/wpvulnerability-run.php
+++ b/wpvulnerability-run.php
@@ -847,8 +847,7 @@ function wpvulnerability_counter_core() {
 		if ( isset( $submenu['index.php'] ) ) {
 			foreach ( $submenu['index.php'] as $key => $value ) {
 				if ( 'update-core.php' === $submenu['index.php'][ $key ][2] ) {
-					$update_count                     = $core_updates_count + $wpvulnerability_core_count;
-					$submenu['index.php'][ $key ][0] .= ' <span class="update-plugins" style="background-color: #FFD700; color: #000000;"><span class="update-count" title="' . __( 'Vulnerabilities', 'wpvulnerability' ) . '">' . $update_count . '</span></span>'; // phpcs:ignore
+					$submenu['index.php'][ $key ][0] .= ' <span class="update-plugins" style="background-color: #FFD700; color: #000000;"><span class="update-count" title="' . __( 'Vulnerabilities', 'wpvulnerability' ) . '">' . $wpvulnerability_core_total . '</span></span>'; // phpcs:ignore
 					break;
 				}
 			}


### PR DESCRIPTION
Problem
- After installing the latest published version from wordpress.org and running the command `wp wpvulnerability core', I was not able to access my site's administrative dashboard anymore.

Cause
- PHP Fatal Error due to a orphaned variable `$core_updates_count` on line 850.

Details
- Error log showed:
```
[22-Aug-2024 09:15:13 UTC] PHP Fatal error:  Uncaught TypeError: Unsupported operand types: null + string in /wp-content/plugins/wpvulnerability/wpvulnerability-run.php:850
Stack trace:
#0 /wp-includes/class-wp-hook.php(324): wpvulnerability_counter_core('')
#1 /wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#2 /wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /wp-admin/includes/menu.php(161): do_action('admin_menu', '')
#4 /wp-admin/menu.php(417): require_once('/var/www/share/...')
#5 /wp-admin/admin.php(158): require('/var/www/share/...')
#6 /wp-admin/index.php(10): require_once('/var/www/share/...')
#7 {main}
  thrown in /wp-content/plugins/wpvulnerability/wpvulnerability-run.php on line 850
```

Proposed solution
1. Replace the undefined variable with the count of core vulnerabilities.

QA
- With the fix applied the menu item "Updates" shows the expected count of core vulnerabilities, whereas the menu item "Plugins" shows the count of plugin vulnerabilities:
![core](https://github.com/user-attachments/assets/fba92a6b-1727-43b0-b238-01037784d886)
![plugins](https://github.com/user-attachments/assets/90a755fa-0bbd-4fd0-8398-c46ccf9ce1ed)

Notes
- It's not clear how such a fundamental error was able to slip through the cracks before creating a release. This should have come up when visiting the admin UI.  Maybe only the CLI command was tested before creating the release?